### PR TITLE
refactor: fix type inconsistency and more

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,60 +9,12 @@ parameters:
 	excludePaths:
 	ignoreErrors:
 	    -
-	        message: '#Cannot use \+\+ on array\|bool\|float\|int\|object\|string\|null.#'
-	        paths:
-	            - src/Commands/QueueWork.php
-	    -
-	        message: '#Variable \$config on left side of \?\?\= always exists and is not nullable.#'
-	        paths:
-	            - src/Config/Services.php
-	    -
-	        message: '#Call to an undefined method CodeIgniter\\Queue\\Handlers\\BaseHandler::push\(\).#'
-	        paths:
-	            - src/Handlers/BaseHandler.php
-	    -
 	        message: '#Call to deprecated function random_string\(\):#'
 	        paths:
 	            - src/Handlers/RedisHandler.php
 	            - src/Handlers/PredisHandler.php
 	    -
-	        message: '#Cannot access property \$timestamp on array\|bool\|float\|int\|object\|string.#'
-	        paths:
-	            - tests/_support/Database/Seeds/TestRedisQueueSeeder.php
-	    -
 	        message: '#Access to an undefined property CodeIgniter\\I18n\\Time::\$timestamp.#'
-	        paths:
-	            - src/Handlers/BaseHandler.php
-	            - src/Handlers/DatabaseHandler.php
-	            - src/Handlers/RedisHandler.php
-	            - src/Handlers/PredisHandler.php
-	            - src/Models/QueueJobModel.php
-	            - tests/RedisHandlerTest.php
-	            - tests/PredisHandlerTest.php
-	    -
-	        message: '#Call to an undefined method CodeIgniter\\Queue\\Models\\QueueJobFailedModel::affectedRows\(\).#'
-	        paths:
-	            - src/Handlers/BaseHandler.php
-	    -
-	        message: '#Call to an undefined method CodeIgniter\\Queue\\Models\\QueueJobFailedModel::truncate\(\).#'
-	        paths:
-	            - src/Handlers/BaseHandler.php
-	    -
-	        message: '#Parameter \#3 \$tries of method CodeIgniter\\Queue\\Commands\\QueueWork::handleWork\(\) expects int\|null, string\|true\|null given.#'
-	        paths:
-	            - src/Commands/QueueWork.php
-	    -
-	        message: '#Parameter \#4 \$retryAfter of method CodeIgniter\\Queue\\Commands\\QueueWork::handleWork\(\) expects int\|null, string\|true\|null given.#'
-	        paths:
-	            - src/Commands/QueueWork.php
-	    -
-	        message: '#Expression on left side of \?\? is not nullable.#'
-	        paths:
-	            - src/Commands/QueueWork.php
-	    -
-	        message: '#Variable \$job might not be defined.#'
-	        paths:
-	            - src/Commands/QueueWork.php
 	universalObjectCratesClasses:
 		- CodeIgniter\Entity
 		- CodeIgniter\Entity\Entity

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,14 @@ parameters:
 	            - src/Handlers/PredisHandler.php
 	    -
 	        message: '#Access to an undefined property CodeIgniter\\I18n\\Time::\$timestamp.#'
+	    -
+	        message: '#Call to an undefined method CodeIgniter\\Queue\\Models\\QueueJobFailedModel::affectedRows\(\).#'
+	        paths:
+	            - src/Handlers/BaseHandler.php
+	    -
+	        message: '#Call to an undefined method CodeIgniter\\Queue\\Models\\QueueJobFailedModel::truncate\(\).#'
+	        paths:
+	            - src/Handlers/BaseHandler.php
 	universalObjectCratesClasses:
 		- CodeIgniter\Entity
 		- CodeIgniter\Entity\Entity

--- a/src/Commands/QueueWork.php
+++ b/src/Commands/QueueWork.php
@@ -192,7 +192,7 @@ class QueueWork extends BaseCommand
 
             CLI::write('The processing of this job was successful', 'green');
         } catch (Throwable $err) {
-            if (isset($job) && ++$work->attempts < $tries ?? $job->getTries()) {
+            if (isset($job) && ++$work->attempts < ($tries ?? $job->getTries())) {
                 // Schedule for later
                 service('queue')->later($work, $retryAfter ?? $job->getRetryAfter());
             } else {

--- a/src/Commands/QueueWork.php
+++ b/src/Commands/QueueWork.php
@@ -94,7 +94,9 @@ class QueueWork extends BaseCommand
         $memory     = $params['memory'] ?? CLI::getOption('memory') ?? 128;
         $priority   = $params['priority'] ?? CLI::getOption('priority') ?? $config->getQueuePriorities($queue) ?? 'default';
         $tries      = $params['tries'] ?? CLI::getOption('tries');
+        $tries      = ($tries !== null) ? (int) $tries : $tries;
         $retryAfter = $params['retry-after'] ?? CLI::getOption('retry-after');
+        $retryAfter = ($retryAfter !== null) ? (int) $retryAfter : $retryAfter;
         $countJobs  = 0;
 
         if (array_key_exists('stop-when-empty', $params) || CLI::getOption('stop-when-empty')) {

--- a/src/Config/Queue.php
+++ b/src/Config/Queue.php
@@ -7,6 +7,8 @@ use CodeIgniter\Queue\Exceptions\QueueException;
 use CodeIgniter\Queue\Handlers\DatabaseHandler;
 use CodeIgniter\Queue\Handlers\PredisHandler;
 use CodeIgniter\Queue\Handlers\RedisHandler;
+use CodeIgniter\Queue\Interfaces\JobInterface;
+use CodeIgniter\Queue\Interfaces\QueueInterface;
 
 class Queue extends BaseConfig
 {
@@ -17,6 +19,8 @@ class Queue extends BaseConfig
 
     /**
      * Available handlers.
+     *
+     * @var array<string, class-string<QueueInterface>>
      */
     public array $handlers = [
         'database' => DatabaseHandler::class,
@@ -81,6 +85,8 @@ class Queue extends BaseConfig
 
     /**
      * Your jobs handlers.
+     *
+     * @var array<string, class-string<JobInterface>>
      */
     public array $jobHandlers = [];
 
@@ -95,6 +101,8 @@ class Queue extends BaseConfig
 
     /**
      * Resolve job class name.
+     *
+     * @return class-string<JobInterface>
      */
     public function resolveJobClass(string $name): string
     {

--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -15,7 +15,7 @@ class Services extends BaseService
             return static::getSharedInstance('queue', $config);
         }
 
-        /** @var QueueConfig $config */
+        /** @var QueueConfig|null $config */
         $config ??= config('Queue');
 
         return (new Queue($config))->init();

--- a/src/Entities/QueueJob.php
+++ b/src/Entities/QueueJob.php
@@ -3,7 +3,18 @@
 namespace CodeIgniter\Queue\Entities;
 
 use CodeIgniter\Entity\Entity;
+use CodeIgniter\I18n\Time;
 
+/**
+ * @property int    $attempts
+ * @property Time   $available_at
+ * @property Time   $created_at
+ * @property int    $id
+ * @property array  $payload
+ * @property string $priority
+ * @property string $queue
+ * @property int    $status
+ */
 class QueueJob extends Entity
 {
     protected $dates = ['available_at', 'created_at'];

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -19,6 +19,18 @@ abstract class BaseHandler
     protected QueueConfig $config;
     protected ?string $priority = null;
 
+    abstract public function push(string $queue, string $job, array $data): bool;
+
+    abstract public function pop(string $queue, array $priorities): ?QueueJob;
+
+    abstract public function later(QueueJob $queueJob, int $seconds): bool;
+
+    abstract public function failed(QueueJob $queueJob, Throwable $err, bool $keepJob): bool;
+
+    abstract public function done(QueueJob $queueJob, bool $keepJob): bool;
+
+    abstract public function clear(?string $queue = null): bool;
+
     /**
      * Set priority for job queue.
      */

--- a/src/Handlers/PredisHandler.php
+++ b/src/Handlers/PredisHandler.php
@@ -80,7 +80,7 @@ class PredisHandler extends BaseHandler implements QueueInterface
         $queueJob->status = Status::RESERVED->value;
         $queueJob->syncOriginal();
 
-        $this->predis->hset("queues:{$queue}::reserved", $queueJob->id, json_encode($queueJob));
+        $this->predis->hset("queues:{$queue}::reserved", (string) $queueJob->id, json_encode($queueJob));
 
         return $queueJob;
     }

--- a/src/Handlers/PredisHandler.php
+++ b/src/Handlers/PredisHandler.php
@@ -94,7 +94,7 @@ class PredisHandler extends BaseHandler implements QueueInterface
         $queueJob->available_at = Time::now()->addSeconds($seconds)->timestamp;
 
         if ($result = $this->predis->zadd("queues:{$queueJob->queue}:{$queueJob->priority}", [json_encode($queueJob) => $queueJob->available_at->timestamp])) {
-            $this->predis->hdel("queues:{$queueJob->queue}::reserved", $queueJob->id);
+            $this->predis->hdel("queues:{$queueJob->queue}::reserved", [$queueJob->id]);
         }
 
         return $result > 0;
@@ -109,7 +109,7 @@ class PredisHandler extends BaseHandler implements QueueInterface
             $this->logFailed($queueJob, $err);
         }
 
-        return (bool) $this->predis->hdel("queues:{$queueJob->queue}::reserved", $queueJob->id);
+        return (bool) $this->predis->hdel("queues:{$queueJob->queue}::reserved", [$queueJob->id]);
     }
 
     /**
@@ -122,7 +122,7 @@ class PredisHandler extends BaseHandler implements QueueInterface
             $this->predis->lpush("queues:{$queueJob->queue}::done", [json_encode($queueJob)]);
         }
 
-        return (bool) $this->predis->hdel("queues:{$queueJob->queue}::reserved", $queueJob->id);
+        return (bool) $this->predis->hdel("queues:{$queueJob->queue}::reserved", [$queueJob->id]);
     }
 
     /**

--- a/src/Handlers/RedisHandler.php
+++ b/src/Handlers/RedisHandler.php
@@ -99,7 +99,7 @@ class RedisHandler extends BaseHandler implements QueueInterface
         $queueJob->status = Status::RESERVED->value;
         $queueJob->syncOriginal();
 
-        $this->redis->hSet("queues:{$queue}::reserved", $queueJob->id, json_encode($queueJob));
+        $this->redis->hSet("queues:{$queue}::reserved", (string) $queueJob->id, json_encode($queueJob));
 
         return $queueJob;
     }
@@ -115,7 +115,7 @@ class RedisHandler extends BaseHandler implements QueueInterface
         $queueJob->available_at = Time::now()->addSeconds($seconds)->timestamp;
 
         if ($result = (int) $this->redis->zAdd("queues:{$queueJob->queue}:{$queueJob->priority}", $queueJob->available_at->timestamp, json_encode($queueJob))) {
-            $this->redis->hDel("queues:{$queueJob->queue}::reserved", $queueJob->id);
+            $this->redis->hDel("queues:{$queueJob->queue}::reserved", (string) $queueJob->id);
         }
 
         return $result > 0;
@@ -130,7 +130,7 @@ class RedisHandler extends BaseHandler implements QueueInterface
             $this->logFailed($queueJob, $err);
         }
 
-        return (bool) $this->redis->hDel("queues:{$queueJob->queue}::reserved", $queueJob->id);
+        return (bool) $this->redis->hDel("queues:{$queueJob->queue}::reserved", (string) $queueJob->id);
     }
 
     /**
@@ -145,7 +145,7 @@ class RedisHandler extends BaseHandler implements QueueInterface
             $this->redis->lPush("queues:{$queueJob->queue}::done", json_encode($queueJob));
         }
 
-        return (bool) $this->redis->hDel("queues:{$queueJob->queue}::reserved", $queueJob->id);
+        return (bool) $this->redis->hDel("queues:{$queueJob->queue}::reserved", (string) $queueJob->id);
     }
 
     /**

--- a/src/Interfaces/JobInterface.php
+++ b/src/Interfaces/JobInterface.php
@@ -7,4 +7,8 @@ interface JobInterface
     public function __construct(array $data);
 
     public function process();
+
+    public function getRetryAfter(): int;
+
+    public function getTries(): int;
 }

--- a/tests/_support/Database/Seeds/TestRedisQueueSeeder.php
+++ b/tests/_support/Database/Seeds/TestRedisQueueSeeder.php
@@ -40,7 +40,7 @@ class TestRedisQueueSeeder extends Seeder
             'attempts'     => 0,
             'available_at' => 1_697_269_864,
         ]);
-        $redis->hSet("queues:{$jobQueue->queue}::reserved", $jobQueue->id, json_encode($jobQueue));
+        $redis->hSet("queues:{$jobQueue->queue}::reserved", (string) $jobQueue->id, json_encode($jobQueue));
 
         $jobQueue = new QueueJob([
             'id'           => '1234567890654321',

--- a/tests/_support/Jobs/Success.php
+++ b/tests/_support/Jobs/Success.php
@@ -8,7 +8,7 @@ use CodeIgniter\Queue\Interfaces\JobInterface;
 class Success extends BaseJob implements JobInterface
 {
     protected int $retryAfter = 6;
-    protected int $retries    = 3;
+    protected int $tries      = 3;
 
     public function process(): bool
     {


### PR DESCRIPTION
**Description**
This PR is based on @kenjis PR: #11. It fixes some more errors catched by phpstan and adds slightly better validation for command options.

Since these are valid calls, I had to suppress calls to methods: `QueueJobFailedModel::affectedRows()` and `QueueJobFailedModel::truncate()`. I guess phpstan can't get what we do in the model.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
