### PR TITLE
fix: typo in the `queue:work` param

### DIFF
--- a/src/Commands/QueueWork.php
+++ b/src/Commands/QueueWork.php
@@ -200,7 +200,7 @@ class QueueWork extends BaseCommand
         ];
 
         // Options that, being defined, cannot be `true`
-        $keys = ['sleep', 'rest', 'maxJobs', 'maxTime', 'memory', 'priority', 'tries', 'retyAfter'];
+        $keys = ['sleep', 'rest', 'maxJobs', 'maxTime', 'memory', 'priority', 'tries', 'retryAfter'];
 
         foreach ($keys as $key) {
             if ($options[$key] === true) {


### PR DESCRIPTION
**Description**
This PR fixes a typo in the `queue:work` param. It's time to think of testing commands somehow.

Fixes: #17

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
