### PR TITLE
tests: add base tests for commands

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -62,5 +62,5 @@ jobs:
 
       - name: Analyze for refactoring
         run: |
-          composer global require --dev rector/rector:^0.15.1
+          composer global require --dev rector/rector:^0.18.12
           rector process --dry-run --no-progress-bar

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": "^4.3",
         "predis/predis": "^2.0",
-        "phpstan/phpstan-strict-rules": "^1.5"
+        "phpstan/phpstan-strict-rules": "^1.5",
+        "rector/rector": "0.18.12"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": "^4.3",
         "predis/predis": "^2.0",
-        "phpstan/phpstan-strict-rules": "^1.5",
-        "rector/rector": "0.18.12"
+        "phpstan/phpstan-strict-rules": "^1.5"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,7 +24,8 @@
             <directory suffix=".php">./src/</directory>
         </include>
         <exclude>
-            <directory suffix=".php">./src/Commands</directory>
+            <directory suffix=".php">./src/Commands/Generators</directory>
+            <directory suffix=".php">./src/Commands/Utils</directory>
             <directory suffix=".php">./src/Config</directory>
         </exclude>
         <report>

--- a/rector.php
+++ b/rector.php
@@ -63,9 +63,10 @@ return static function (RectorConfig $rectorConfig): void {
         realpath(getcwd()) . '/vendor/codeigniter4/framework/system/Test/bootstrap.php',
     ]);
 
-    if (is_file(__DIR__ . '/phpstan.neon.dist')) {
-        $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon.dist');
-    }
+    $rectorConfig->phpstanConfigs([
+        __DIR__ . '/phpstan.neon.dist',
+        __DIR__ . '/vendor/phpstan/phpstan-strict-rules/rules.neon',
+    ]);
 
     // Set the target version for refactoring
     $rectorConfig->phpVersion(PhpVersion::PHP_81);

--- a/rector.php
+++ b/rector.php
@@ -65,7 +65,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->phpstanConfigs([
         __DIR__ . '/phpstan.neon.dist',
-        __DIR__ . '/vendor/phpstan/phpstan-strict-rules/rules.neon',
+        //__DIR__ . '/vendor/phpstan/phpstan-strict-rules/rules.neon',
     ]);
 
     // Set the target version for refactoring

--- a/rector.php
+++ b/rector.php
@@ -65,7 +65,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->phpstanConfigs([
         __DIR__ . '/phpstan.neon.dist',
-        //__DIR__ . '/vendor/phpstan/phpstan-strict-rules/rules.neon',
+        __DIR__ . '/vendor/phpstan/phpstan-strict-rules/rules.neon',
     ]);
 
     // Set the target version for refactoring

--- a/src/Commands/QueueFailed.php
+++ b/src/Commands/QueueFailed.php
@@ -64,7 +64,13 @@ class QueueFailed extends BaseCommand
         $tbody = [];
 
         foreach ($results as $result) {
-            $tbody[] = [$result->id, $result->connection, $result->queue, $this->getClassName($result->payload['job'], $config), $result->failed_at];
+            $tbody[] = [
+                $result->id,
+                $result->connection,
+                $result->queue,
+                $this->getClassName($result->payload['job'], $config),
+                $result->failed_at,
+            ];
         }
 
         CLI::table($tbody, $thead);

--- a/src/Commands/QueueFailed.php
+++ b/src/Commands/QueueFailed.php
@@ -56,7 +56,7 @@ class QueueFailed extends BaseCommand
         $queue = $params['queue'] ?? CLI::getOption('queue');
 
         /** @var QueueConfig $config */
-        $config = config('queue');
+        $config = config('Queue');
 
         $results = service('queue')->listFailed($queue);
 

--- a/src/Commands/QueuePublish.php
+++ b/src/Commands/QueuePublish.php
@@ -13,7 +13,7 @@ class QueuePublish extends BaseCommand
 {
     protected $group       = 'Queue';
     protected $name        = 'queue:publish';
-    protected $description = 'Publish QueueJob config file into the current application.';
+    protected $description = 'Publish Queue config file into the current application.';
 
     public function run(array $params): void
     {

--- a/src/Commands/QueueStop.php
+++ b/src/Commands/QueueStop.php
@@ -72,7 +72,7 @@ class QueueStop extends BaseCommand
 
         cache()->save($cacheName, $startTime, MINUTE * 10);
 
-        CLI::write('QueueJob will be stopped after the current job finish', 'yellow');
+        CLI::write('Queue will be stopped after the current job finish', 'yellow');
 
         return EXIT_SUCCESS;
     }

--- a/tests/Commands/QueueClearTest.php
+++ b/tests/Commands/QueueClearTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Tests\Support\CLITestCase;
+
+/**
+ * @internal
+ */
+final class QueueClearTest extends CLITestCase
+{
+    public function testRunWithNoQueueName(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addErrorFilter();
+
+        $this->assertNotFalse(command('queue:clear'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeErrorFilter();
+
+        $this->assertSame('The queueName is not specified.', $output);
+    }
+
+    public function testRun(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:clear test'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('Queue test has been cleared.', $output);
+    }
+}

--- a/tests/Commands/QueueFailedTest.php
+++ b/tests/Commands/QueueFailedTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Queue\Models\QueueJobFailedModel;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Exception;
+use Tests\Support\CLITestCase;
+
+/**
+ * @internal
+ */
+final class QueueFailedTest extends CLITestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testRun(): void
+    {
+        Time::setTestNow('2023-12-19 14:15:16');
+
+        fake(QueueJobFailedModel::class, [
+            'connection' => 'database',
+            'queue'      => 'test',
+            'payload'    => ['job' => 'failure', 'data' => ['key' => 'value']],
+            'priority'   => 'default',
+            'exception'  => 'Exception: Test error',
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:failed'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $expect = <<<'EOT'
+            +----+------------+-------+----------------------------+---------------------+
+            | ID | Connection | Queue | Class                      | Failed At           |
+            +----+------------+-------+----------------------------+---------------------+
+            | 1  | database   | test  | Tests\Support\Jobs\Failure | 2023-12-19 14:15:16 |
+            +----+------------+-------+----------------------------+---------------------+
+            EOT;
+
+        $this->assertSame($expect, $output);
+    }
+}

--- a/tests/Commands/QueueFlushTest.php
+++ b/tests/Commands/QueueFlushTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Queue\Models\QueueJobFailedModel;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Exception;
+use Tests\Support\CLITestCase;
+
+/**
+ * @internal
+ */
+final class QueueFlushTest extends CLITestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testRun(): void
+    {
+        Time::setTestNow('2023-12-19 14:15:16');
+
+        fake(QueueJobFailedModel::class, [
+            'connection' => 'database',
+            'queue'      => 'test',
+            'payload'    => ['job' => 'failure', 'data' => ['key' => 'value']],
+            'priority'   => 'default',
+            'exception'  => 'Exception: Test error',
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:flush'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('All failed jobs has been removed from the queue ', $output);
+    }
+
+    public function testRunWithQueue(): void
+    {
+        Time::setTestNow('2023-12-19 14:15:16');
+
+        fake(QueueJobFailedModel::class, [
+            'connection' => 'database',
+            'queue'      => 'test',
+            'payload'    => ['job' => 'failure', 'data' => ['key' => 'value']],
+            'priority'   => 'default',
+            'exception'  => 'Exception: Test error',
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:flush -queue default'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('All failed jobs has been removed from the queue default', $output);
+    }
+
+    public function testRunWithQueueAndHour(): void
+    {
+        Time::setTestNow('2023-12-19 14:15:16');
+
+        fake(QueueJobFailedModel::class, [
+            'connection' => 'database',
+            'queue'      => 'test',
+            'payload'    => ['job' => 'failure', 'data' => ['key' => 'value']],
+            'priority'   => 'default',
+            'exception'  => 'Exception: Test error',
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:flush -queue default -hours 2'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('All failed jobs older than 2 hours has been removed from the queue default', $output);
+    }
+}

--- a/tests/Commands/QueueForgetTest.php
+++ b/tests/Commands/QueueForgetTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\Queue\Models\QueueJobFailedModel;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Tests\Support\CLITestCase;
+
+/**
+ * @internal
+ */
+final class QueueForgetTest extends CLITestCase
+{
+    public function testRunWithNoQueueName(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addErrorFilter();
+
+        $this->assertNotFalse(command('queue:forget'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeErrorFilter();
+
+        $this->assertSame('The ID of the failed job is not specified.', $output);
+    }
+
+    public function testRunFailed(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:forget 123'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('Could not find the failed job with ID 123', $output);
+    }
+
+    public function testRun(): void
+    {
+        fake(QueueJobFailedModel::class, [
+            'connection' => 'database',
+            'queue'      => 'test',
+            'payload'    => ['job' => 'failure', 'data' => ['key' => 'value']],
+            'priority'   => 'default',
+            'exception'  => 'Exception: Test error',
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:forget 1'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('Failed job with ID 1 has been removed.', $output);
+    }
+}

--- a/tests/Commands/QueuePublishTest.php
+++ b/tests/Commands/QueuePublishTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Tests\Support\CLITestCase;
+
+/**
+ * @internal
+ */
+final class QueuePublishTest extends CLITestCase
+{
+    public function testRun(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:publish'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('  Published! You can customize the configuration by editing the "app/Config/Queue.php" file.', $output);
+    }
+}

--- a/tests/Commands/QueueRetryTest.php
+++ b/tests/Commands/QueueRetryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\Queue\Models\QueueJobFailedModel;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Tests\Support\CLITestCase;
+
+/**
+ * @internal
+ */
+final class QueueRetryTest extends CLITestCase
+{
+    public function testRunWithNoQueueName(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addErrorFilter();
+
+        $this->assertNotFalse(command('queue:retry'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeErrorFilter();
+
+        $this->assertSame('The ID of the failed job is not specified.', $output);
+    }
+
+    public function testRunFailed(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:retry all -queue test'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('No failed jobs has been restored to the queue test', $output);
+    }
+
+    public function testRun(): void
+    {
+        fake(QueueJobFailedModel::class, [
+            'connection' => 'database',
+            'queue'      => 'test',
+            'payload'    => ['job' => 'failure', 'data' => ['key' => 'value']],
+            'priority'   => 'default',
+            'exception'  => 'Exception: Test error',
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:retry 1'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('1 failed job(s) has been restored to the queue ', $output);
+    }
+}

--- a/tests/Commands/QueueStopTest.php
+++ b/tests/Commands/QueueStopTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Tests\Support\CLITestCase;
+
+/**
+ * @internal
+ */
+final class QueueStopTest extends CLITestCase
+{
+    public function testRunWithNoQueueName(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addErrorFilter();
+
+        $this->assertNotFalse(command('queue:stop'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeErrorFilter();
+
+        $this->assertSame('The queueName is not specified.', $output);
+    }
+
+    public function testRun(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:stop test'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('Queue will be stopped after the current job finish', $output);
+    }
+}

--- a/tests/Commands/QueueWorkTest.php
+++ b/tests/Commands/QueueWorkTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Queue\Models\QueueJobModel;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Tests\Support\CLITestCase;
+
+/**
+ * @internal
+ */
+final class QueueWorkTest extends CLITestCase
+{
+    public function testRunWithNoQueueName(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addErrorFilter();
+
+        $this->assertNotFalse(command('queue:work'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeErrorFilter();
+
+        $this->assertSame('The queueName is not specified.', $output);
+    }
+
+    public function testRunWithEmptyQueue(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:work test --stop-when-empty'));
+        $output = $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $expect = <<<'EOT'
+            Listening for the jobs with the queue: test
+
+
+            No job available. Stopping.
+            EOT;
+
+        $this->assertSame($expect, $output);
+    }
+
+    public function testRunWithQueueFailed(): void
+    {
+        Time::setTestNow('2023-12-19 14:15:16');
+
+        fake(QueueJobModel::class, [
+            'connection'   => 'database',
+            'queue'        => 'test',
+            'payload'      => ['job' => 'failure', 'data' => ['key' => 'value']],
+            'priority'     => 'default',
+            'status'       => 0,
+            'attempts'     => 0,
+            'available_at' => 1_702_977_074,
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:work test sleep 1 --stop-when-empty'));
+        $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('Listening for the jobs with the queue: test', $this->getLine(0));
+        $this->assertSame('Starting a new job: failure, with ID: 1', $this->getLine(3));
+        $this->assertSame('The processing of this job failed', $this->getLine(4));
+        $this->assertSame('No job available. Stopping.', $this->getLine(7));
+    }
+
+    public function testRunWithQueueSucceed(): void
+    {
+        Time::setTestNow('2023-12-19 14:15:16');
+
+        fake(QueueJobModel::class, [
+            'connection'   => 'database',
+            'queue'        => 'test',
+            'payload'      => ['job' => 'success', 'data' => ['key' => 'value']],
+            'priority'     => 'default',
+            'status'       => 0,
+            'attempts'     => 0,
+            'available_at' => 1_702_977_074,
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:work test sleep 1 --stop-when-empty'));
+        $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('Listening for the jobs with the queue: test', $this->getLine(0));
+        $this->assertSame('Starting a new job: success, with ID: 1', $this->getLine(3));
+        $this->assertSame('The processing of this job was successful', $this->getLine(4));
+        $this->assertSame('No job available. Stopping.', $this->getLine(7));
+    }
+}

--- a/tests/_support/CLITestCase.php
+++ b/tests/_support/CLITestCase.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\Test\ReflectionHelper;
+
+abstract class CLITestCase extends TestCase
+{
+    use ReflectionHelper;
+
+    private array $lines = [];
+
+    protected function parseOutput(string $output): string
+    {
+        $this->lines = [];
+        $output      = $this->removeColorCodes($output);
+        $this->lines = explode("\n", $output);
+
+        return $output;
+    }
+
+    protected function getLine(int $line = 0): ?string
+    {
+        return $this->lines[$line] ?? null;
+    }
+
+    protected function getLines(): string
+    {
+        return implode('', $this->lines);
+    }
+
+    protected function removeColorCodes(string $output): string
+    {
+        $colors = $this->getPrivateProperty(CLI::class, 'foreground_colors');
+        $colors = array_values(array_map(static fn ($color) => "\033[" . $color . 'm', $colors));
+        $colors = array_merge(["\033[0m"], $colors);
+
+        $output = str_replace($colors, '', trim($output));
+
+        if (is_windows()) {
+            $output = str_replace("\r\n", "\n", $output);
+        }
+
+        return $output;
+    }
+}

--- a/tests/_support/CLITestCase.php
+++ b/tests/_support/CLITestCase.php
@@ -5,13 +5,26 @@ declare(strict_types=1);
 namespace Tests\Support;
 
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\ReflectionHelper;
+use Exception;
 
 abstract class CLITestCase extends TestCase
 {
     use ReflectionHelper;
 
     private array $lines = [];
+
+    /**
+     * @throws Exception
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Reset the current time.
+        Time::setTestNow();
+    }
 
     protected function parseOutput(string $output): string
     {


### PR DESCRIPTION
**Description**
This PR adds basic tests for commands.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
