### PR TITLE
docs: better `hljs` support when `navigation.instant` is enabled

### DIFF
--- a/docs/assets/js/hljs.js
+++ b/docs/assets/js/hljs.js
@@ -1,3 +1,3 @@
-document.addEventListener('DOMContentLoaded', (event) => {
+window.document$.subscribe(() => {
     hljs.highlightAll();
 });


### PR DESCRIPTION
**Description**
This PR adds better support for `hljs` plugin when `navigation.instant` is enabled.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
