### PR TITLE
docs: add `site_url`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,6 @@ theme:
         name: Switch to light mode
   features:
     - navigation.instant
-    - navigation.instant.prefetch
     - content.code.copy
     - navigation.footer
     - content.action.edit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ extra:
       link: https://join.slack.com/t/codeigniterchat/shared_invite/zt-244xrrslc-l_I69AJSi5y2a2RVN~xIdQ
       name: Slack
 
+site_url: https://queue.codeigniter.com/
 repo_url: https://github.com/codeigniter4/queue
 edit_uri: edit/develop/docs/
 copyright: Copyright &copy; 2023 CodeIgniter Foundation.


### PR DESCRIPTION
**Description**
This PR:
- adds `site_url`, to make `navigation.instant` feature work
- removes `navigation.instant.prefetch` feature because it's available only for sponsors of the MkDocs project

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
