### PR TITLE
docs: add missing `.md`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ Listen for queued jobs.
 
 * [Installation](installation.md)
 * [Configuration](configuration.md)
-* [Basic usage](basic-usage)
-* [Running queues](running-queues)
+* [Basic usage](basic-usage.md)
+* [Running queues](running-queues.md)
 * [Commands](commands.md)
 * [Troubleshooting](troubleshooting.md)
 


### PR DESCRIPTION
**Description**
```
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'basic-usage', it was left as is. Did you mean 'basic-usage.md'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'running-queues', it was left as is. Did you mean 'running-queues.md'?
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
