### PR TITLE
docs: add composer minimum-stability instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,31 @@ The only thing you have to do is to run this command, and you're ready to go.
 
     composer require codeigniter4/queue
 
+#### A composer error occurred?
+
+If you get the following error:
+
+```console
+Could not find a version of package codeigniter4/queue matching your minimum-stability (stable).
+Require it with an explicit version constraint allowing its desired stability.
+```
+
+1. Run the following commands to change your [minimum-stability](https://getcomposer.org/doc/articles/versions.md#minimum-stability) in your project `composer.json`:
+
+    ```console
+    composer config minimum-stability dev
+    composer config prefer-stable true
+    ```
+
+2. Or specify an explicit version:
+
+    ```console
+    composer require codeigniter4/queue:dev-develop
+    ```
+
+   The above specifies `develop` branch.
+   See <https://getcomposer.org/doc/articles/versions.md#branches>
+
 ## Manual Installation
 
 In the example below we will assume, that files from this project will be located in `app/ThirdParty/queue` directory.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,3 +5,7 @@
 If you want to assign an object to the queue, please make sure it implements `JsonSerializable` interface. This is how CodeIgniter [Entities](https://codeigniter.com/user_guide/models/entities.html) are handled by default.
 
 You may ask, why not just use `serialize` and `unserialize`? There are security reasons that keep us from doing so. These functions are not safe to use with user provided data.
+
+### I get an error when trying to install via composer.
+
+Please see these [instructions](installation.md/#a-composer-error-occurred).


### PR DESCRIPTION
**Description**
This PR adds instructions to the docs about handling composer minimum-stability errors.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
