### PR TITLE
fix: `connection` name for used handler

### DIFF
--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -30,6 +30,8 @@ abstract class BaseHandler
     protected QueueConfig $config;
     protected ?string $priority = null;
 
+    abstract public function name(): string;
+
     abstract public function push(string $queue, string $job, array $data): bool;
 
     abstract public function pop(string $queue, array $priorities): ?QueueJob;
@@ -144,7 +146,7 @@ abstract class BaseHandler
             "file: {$err->getFile()}:{$err->getLine()}";
 
         $queueJobFailed = new QueueJobFailed([
-            'connection' => 'database',
+            'connection' => $this->name(),
             'queue'      => $queueJob->queue,
             'payload'    => $queueJob->payload,
             'priority'   => $queueJob->priority,

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -34,6 +34,14 @@ class DatabaseHandler extends BaseHandler implements QueueInterface
     }
 
     /**
+     * Name of the handler.
+     */
+    public function name(): string
+    {
+        return 'database';
+    }
+
+    /**
      * Add job to the queue.
      *
      * @throws ReflectionException

--- a/src/Handlers/PredisHandler.php
+++ b/src/Handlers/PredisHandler.php
@@ -39,6 +39,14 @@ class PredisHandler extends BaseHandler implements QueueInterface
     }
 
     /**
+     * Name of the handler.
+     */
+    public function name(): string
+    {
+        return 'predis';
+    }
+
+    /**
      * Add job to the queue.
      */
     public function push(string $queue, string $job, array $data): bool

--- a/src/Handlers/RedisHandler.php
+++ b/src/Handlers/RedisHandler.php
@@ -54,6 +54,14 @@ class RedisHandler extends BaseHandler implements QueueInterface
     }
 
     /**
+     * Name of the handler.
+     */
+    public function name(): string
+    {
+        return 'redis';
+    }
+
+    /**
      * Add job to the queue.
      *
      * @throws RedisException

--- a/tests/PredisHandlerTest.php
+++ b/tests/PredisHandlerTest.php
@@ -182,7 +182,7 @@ final class PredisHandlerTest extends TestCase
 
         $this->seeInDatabase('queue_jobs_failed', [
             'id'         => 2,
-            'connection' => 'database',
+            'connection' => 'predis',
             'queue'      => 'queue1',
         ]);
     }
@@ -206,7 +206,7 @@ final class PredisHandlerTest extends TestCase
 
         $this->dontSeeInDatabase('queue_jobs_failed', [
             'id'         => 2,
-            'connection' => 'database',
+            'connection' => 'predis',
             'queue'      => 'queue1',
         ]);
     }

--- a/tests/RedisHandlerTest.php
+++ b/tests/RedisHandlerTest.php
@@ -166,7 +166,7 @@ final class RedisHandlerTest extends TestCase
 
         $this->seeInDatabase('queue_jobs_failed', [
             'id'         => 2,
-            'connection' => 'database',
+            'connection' => 'redis',
             'queue'      => 'queue1',
         ]);
     }
@@ -187,7 +187,7 @@ final class RedisHandlerTest extends TestCase
 
         $this->dontSeeInDatabase('queue_jobs_failed', [
             'id'         => 2,
-            'connection' => 'database',
+            'connection' => 'redis',
             'queue'      => 'queue1',
         ]);
     }


### PR DESCRIPTION
**Description**
This PR fixes the `connection` name we set in the `queue_jobs_failed` table. Now the name is properly set, depending on the used handler.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
