### PR TITLE
Add an additional condition before `reconnect()`

### DIFF
--- a/src/Models/QueueJobModel.php
+++ b/src/Models/QueueJobModel.php
@@ -51,7 +51,7 @@ class QueueJobModel extends Model
     {
         // For SQLite3 memory database this will cause problems
         // so check if we're not in the testing environment first.
-        if ($this->db->database !== ':memory:') {
+        if ($this->db->database !== ':memory:' && $this->db->connID !== false) {
             // Make sure we still have the connection
             $this->db->reconnect();
         }


### PR DESCRIPTION
**Description**
This PR checks if the connection has been established before we call the `reconnect()` method.

When a connection to the database is lost, the `$this->db->connID` remains valid in terms of its existence, but the actual connection might be closed or invalid.

There are no actual tests for this because I don't know how I can test it - we have a valid DB connection during the tests. Although I confirmed this was a bug and this change fixes it.

Needs ~#46~

Fixes #45

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
