### PR TITLE
Add `skipLocked` config for the `database` handler

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ The configuration settings for `database` handler.
 
 * `dbGroup` - The database group to use. Default value: `default`.
 * `getShared` - Weather to use shared instance. Default value: `true`.
+* `skipLocked` - Weather to use "skip locked" feature to maintain concurrency calls. Default to `true`.
 
 ### $redis
 

--- a/docs/running-queues.md
+++ b/docs/running-queues.md
@@ -65,7 +65,7 @@ This way, worker will consume jobs with the `low` priority and then with `high`.
 
 ### Running many instances of the same queue
 
-As mentioned above, sometimes we may want to have multiple instances of the same command running at the same time. The queue is safe to use in that scenario with all databases except `SQLite3` since it doesn't guarantee that the job will be selected only by one process.
+As mentioned above, sometimes we may want to have multiple instances of the same command running at the same time. The queue is safe to use in that scenario with all databases if you keep the `skipLocked` to `true` in the config file. Only for SQLite3 driver this setting is not relevant.
 
 ### Handling long-running process
 

--- a/src/Config/Queue.php
+++ b/src/Config/Queue.php
@@ -45,6 +45,9 @@ class Queue extends BaseConfig
     public array $database = [
         'dbGroup'   => 'default',
         'getShared' => true,
+        // use skip locked feature to maintain concurrency calls
+        // this is not relevant for the SQLite3 database driver
+        'skipLocked' => true,
     ];
 
     /**

--- a/src/Models/QueueJobModel.php
+++ b/src/Models/QueueJobModel.php
@@ -90,7 +90,7 @@ class QueueJobModel extends Model
      */
     private function skipLocked(string $sql): string
     {
-        if ($this->db->DBDriver === 'SQLite3') {
+        if ($this->db->DBDriver === 'SQLite3' || config('Queue')->database['skipLocked'] === false) {
             return $sql;
         }
 

--- a/tests/Models/QueueJobModelTest.php
+++ b/tests/Models/QueueJobModelTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Queue.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Models;
+
+use CodeIgniter\Queue\Models\QueueJobModel;
+use CodeIgniter\Test\ReflectionHelper;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class QueueJobModelTest extends TestCase
+{
+    use ReflectionHelper;
+
+    public function testQueueJobModel(): void
+    {
+        $model = model(QueueJobModel::class);
+        $this->assertInstanceOf(QueueJobModel::class, $model);
+    }
+
+    public function testSkipLocked(): void
+    {
+        $model  = model(QueueJobModel::class);
+        $method = $this->getPrivateMethodInvoker($model, 'skipLocked');
+
+        $sql    = 'SELECT * FROM queue_jobs WHERE queue = "test" AND status = 0 AND available_at < 123456 LIMIT 1';
+        $result = $method($sql);
+
+        if ($model->db->DBDriver === 'SQLite3') {
+            $this->assertSame($sql, $result);
+        } elseif ($model->db->DBDriver === 'SQLSRV') {
+            $expected = 'SELECT * FROM queue_jobs WITH (ROWLOCK,UPDLOCK,READPAST) WHERE queue = "test" AND status = 0 AND available_at < 123456 LIMIT 1';
+            $this->assertSame($expected, $result);
+        } else {
+            $expected = 'SELECT * FROM queue_jobs WHERE queue = "test" AND status = 0 AND available_at < 123456 LIMIT 1 FOR UPDATE SKIP LOCKED';
+            $this->assertSame($expected, $result);
+        }
+    }
+
+    public function testSkipLockedFalse(): void
+    {
+        config('Queue')->database['skipLocked'] = false;
+
+        $model  = model(QueueJobModel::class);
+        $method = $this->getPrivateMethodInvoker($model, 'skipLocked');
+
+        $sql    = 'SELECT * FROM queue_jobs WHERE queue = "test" AND status = 0 AND available_at < 123456 LIMIT 1';
+        $result = $method($sql);
+
+        $this->assertSame($sql, $result);
+    }
+}

--- a/tests/_support/Config/Queue.php
+++ b/tests/_support/Config/Queue.php
@@ -40,8 +40,9 @@ class Queue extends BaseQueue
      * Database handler config.
      */
     public array $database = [
-        'dbGroup'   => 'default',
-        'getShared' => true,
+        'dbGroup'    => 'default',
+        'getShared'  => true,
+        'skipLocked' => true,
     ];
 
     /**


### PR DESCRIPTION
**Description**
This PR adds `skipLocked` config for the `database` handler.

Since using a "skip-locked rows" query can be problematic for some users, I decided to introduce a config option for this purpose.

If the developer runs only one instance of the same queue, it will be safe to set `skipLocked` to `false` and use it without worrying about the required database version. This is a fair compromise for those who do not use the queue intensively.

Needs: ~#47~

Fixes: #42

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
