### PR TITLE
Add an option to delay job execution when adding to the queue

### DIFF
--- a/docs/running-queues.md
+++ b/docs/running-queues.md
@@ -12,7 +12,7 @@ This will cause command to check for the new jobs every 10 seconds if the queue 
 
 ### With CRON
 
-Using queues with CRON is more challenging, but definitely doable. You can use command like this:
+Using queues with CRON is more challenging but definitely doable. You can use command like this:
 
     php spark queue:work emails -max-jobs 20 --stop-when-empty
 
@@ -62,6 +62,22 @@ But we can also run the worker like this:
     php spark queue:work emails -priority low,high
 
 This way, worker will consume jobs with the `low` priority and then with `high`. The order set in the config file is override.
+
+### Delaying jobs
+
+Normally, when we add jobs to a queue, they are run in the order in which we added them to the queue (FIFO - first in, first out).
+Of course, there are also priorities, which we described in the previous section. But what about the scenario where we want to run a job, but not earlier than in 5 minutes?
+
+This is where job delay comes into play. We measure the delay in seconds.
+
+```php
+// This job will be run not sooner than in 5 minutes
+service('queue')->setDelay(5 * MINUTE)->push('emails', 'email', ['message' => 'Email sent no sooner than 5 minutes from now']);
+```
+
+Note that there is no guarantee that the job will run exactly in 5 minutes. If many new jobs are added to the queue (without a delay), it may take a long time before the delayed job is actually executed.
+
+We can also combine delayed jobs with priorities.
 
 ### Running many instances of the same queue
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         cacheDirectory=".phpunit.cache"
+         cacheDirectory="build/.phpunit.cache"
          beStrictAboutCoverageMetadata="true">
 
     <coverage includeUncoveredFiles="true">

--- a/src/Exceptions/QueueException.php
+++ b/src/Exceptions/QueueException.php
@@ -51,4 +51,9 @@ final class QueueException extends RuntimeException
     {
         return new self(lang('Queue.incorrectQueuePriority', [$priority, $queue]));
     }
+
+    public static function forIncorrectDelayValue(): static
+    {
+        return new self(lang('Queue.incorrectDelayValue'));
+    }
 }

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -29,6 +29,7 @@ abstract class BaseHandler
 {
     protected QueueConfig $config;
     protected ?string $priority = null;
+    protected ?int $delay       = null;
 
     abstract public function name(): string;
 
@@ -58,6 +59,20 @@ abstract class BaseHandler
         }
 
         $this->priority = $priority;
+
+        return $this;
+    }
+
+    /**
+     * Set delay for job queue (in seconds).
+     */
+    public function setDelay(int $delay): static
+    {
+        if ($delay < 0) {
+            throw QueueException::forIncorrectDelayValue();
+        }
+
+        $this->delay = $delay;
 
         return $this;
     }

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -56,10 +56,10 @@ class DatabaseHandler extends BaseHandler implements QueueInterface
             'priority'     => $this->priority,
             'status'       => Status::PENDING->value,
             'attempts'     => 0,
-            'available_at' => Time::now(),
+            'available_at' => Time::now()->addSeconds($this->delay ?? 0),
         ]);
 
-        $this->priority = null;
+        $this->priority = $this->delay = null;
 
         return $this->jobModel->insert($queueJob, false);
     }

--- a/src/Language/en/Queue.php
+++ b/src/Language/en/Queue.php
@@ -24,4 +24,5 @@ return [
     'incorrectPriorityFormat' => 'The priority name should consists only lowercase letters.',
     'tooLongPriorityName'     => 'The priority name is too long. It should be no longer than 64 letters.',
     'incorrectQueuePriority'  => 'This queue has incorrectly defined priority: "{0}" for the queue: "{1}".',
+    'incorrectDelayValue'     => 'The number of seconds of delay must be a positive integer.',
 ];

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -152,7 +152,7 @@ final class DatabaseHandlerTest extends TestCase
     }
 
     /**
-     * @throws ReflectionException
+     * @throws Exception
      */
     public function testPushWithDelay(): void
     {
@@ -162,11 +162,16 @@ final class DatabaseHandlerTest extends TestCase
         $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
 
         $this->assertTrue($result);
+
+        $availableAt = 1703859376;
+
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue-delay',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key' => 'value']]),
-            'available_at' => 1703859376,
+            'available_at' => $availableAt,
         ]);
+
+        $this->assertEqualsWithDelta(MINUTE, $availableAt - Time::now()->getTimestamp(), 1);
     }
 
     public function testPushWithDelayException(): void

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -212,6 +212,15 @@ final class DatabaseHandlerTest extends TestCase
         $this->assertSame($payload, $result->payload);
     }
 
+    public function testPushWithDelayException(): void
+    {
+        $this->expectException(QueueException::class);
+        $this->expectExceptionMessage('The number of seconds of delay must be a positive integer.');
+
+        $handler = new DatabaseHandler($this->config);
+        $handler->setDelay(-60);
+    }
+
     /**
      * @throws ReflectionException
      */

--- a/tests/PredisHandlerTest.php
+++ b/tests/PredisHandlerTest.php
@@ -102,6 +102,60 @@ final class PredisHandlerTest extends TestCase
         $this->assertSame(['key' => 'value'], $queueJob->payload['data']);
     }
 
+    /**
+     * @throws ReflectionException
+     */
+    public function testPushWithDelay(): void
+    {
+        Time::setTestNow('2023-12-29 14:15:16');
+
+        $handler = new PredisHandler($this->config);
+        $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
+
+        $this->assertTrue($result);
+
+        $predis = self::getPrivateProperty($handler, 'predis');
+        $this->assertSame(1, $predis->zcard('queues:queue-delay:default'));
+
+        $task     = $predis->zrangebyscore('queues:queue-delay:default', '-inf', Time::now()->addSeconds(MINUTE)->timestamp, ['limit' => [0, 1]]);
+        $queueJob = new QueueJob(json_decode((string) $task[0], true));
+        $this->assertSame('success', $queueJob->payload['job']);
+        $this->assertSame(['key' => 'value'], $queueJob->payload['data']);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testPushAndPopWithDelay(): void
+    {
+        Time::setTestNow('2023-12-29 14:15:16');
+
+        $handler = new PredisHandler($this->config);
+        $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key1' => 'value1']);
+
+        $this->assertTrue($result);
+
+        $result = $handler->push('queue-delay', 'success', ['key2' => 'value2']);
+
+        $this->assertTrue($result);
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertInstanceOf(QueueJob::class, $result);
+        $payload = ['job' => 'success', 'data' => ['key2' => 'value2']];
+        $this->assertSame($payload, $result->payload);
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertNull($result);
+
+        // add 1 minute
+        Time::setTestNow('2023-12-29 14:16:16');
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertInstanceOf(QueueJob::class, $result);
+        $payload = ['job' => 'success', 'data' => ['key1' => 'value1']];
+        $this->assertSame($payload, $result->payload);
+    }
+
     public function testPushException(): void
     {
         $this->expectException(QueueException::class);

--- a/tests/PredisHandlerTest.php
+++ b/tests/PredisHandlerTest.php
@@ -123,39 +123,6 @@ final class PredisHandlerTest extends TestCase
         $this->assertSame(['key' => 'value'], $queueJob->payload['data']);
     }
 
-    /**
-     * @throws ReflectionException
-     */
-    public function testPushAndPopWithDelay(): void
-    {
-        Time::setTestNow('2023-12-29 14:15:16');
-
-        $handler = new PredisHandler($this->config);
-        $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key1' => 'value1']);
-
-        $this->assertTrue($result);
-
-        $result = $handler->push('queue-delay', 'success', ['key2' => 'value2']);
-
-        $this->assertTrue($result);
-
-        $result = $handler->pop('queue-delay', ['default']);
-        $this->assertInstanceOf(QueueJob::class, $result);
-        $payload = ['job' => 'success', 'data' => ['key2' => 'value2']];
-        $this->assertSame($payload, $result->payload);
-
-        $result = $handler->pop('queue-delay', ['default']);
-        $this->assertNull($result);
-
-        // add 1 minute
-        Time::setTestNow('2023-12-29 14:16:16');
-
-        $result = $handler->pop('queue-delay', ['default']);
-        $this->assertInstanceOf(QueueJob::class, $result);
-        $payload = ['job' => 'success', 'data' => ['key1' => 'value1']];
-        $this->assertSame($payload, $result->payload);
-    }
-
     public function testPushException(): void
     {
         $this->expectException(QueueException::class);

--- a/tests/PushAndPopWithDelayTest.php
+++ b/tests/PushAndPopWithDelayTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Queue.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests;
+
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Queue\Entities\QueueJob;
+use CodeIgniter\Test\ReflectionHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Support\Config\Queue as QueueConfig;
+use Tests\Support\Database\Seeds\TestDatabaseQueueSeeder;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class PushAndPopWithDelayTest extends TestCase
+{
+    use ReflectionHelper;
+
+    protected $seed = TestDatabaseQueueSeeder::class;
+    private QueueConfig $config;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config = config(QueueConfig::class);
+    }
+
+    public static function handlerProvider(): iterable
+    {
+        return [
+            [
+                'database',                                   // name
+                'CodeIgniter\Queue\Handlers\DatabaseHandler', // class
+            ],
+            [
+                'redis',
+                'CodeIgniter\Queue\Handlers\RedisHandler',
+            ],
+            [
+                'predis',
+                'CodeIgniter\Queue\Handlers\PredisHandler',
+            ],
+        ];
+    }
+
+    #[DataProvider('handlerProvider')]
+    public function testPushAndPopWithDelay(string $name, string $class): void
+    {
+        Time::setTestNow('2023-12-29 14:15:16');
+
+        $handler = new $class($this->config);
+        $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key1' => 'value1']);
+
+        $this->assertTrue($result);
+
+        $result = $handler->push('queue-delay', 'success', ['key2' => 'value2']);
+
+        $this->assertTrue($result);
+
+        if ($name === 'database') {
+            $this->seeInDatabase('queue_jobs', [
+                'queue'        => 'queue-delay',
+                'payload'      => json_encode(['job' => 'success', 'data' => ['key1' => 'value1']]),
+                'available_at' => 1703859376,
+            ]);
+
+            $this->seeInDatabase('queue_jobs', [
+                'queue'        => 'queue-delay',
+                'payload'      => json_encode(['job' => 'success', 'data' => ['key2' => 'value2']]),
+                'available_at' => 1703859316,
+            ]);
+        }
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertInstanceOf(QueueJob::class, $result);
+        $payload = ['job' => 'success', 'data' => ['key2' => 'value2']];
+        $this->assertSame($payload, $result->payload);
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertNull($result);
+
+        // add 1 minute
+        Time::setTestNow('2023-12-29 14:16:16');
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertInstanceOf(QueueJob::class, $result);
+        $payload = ['job' => 'success', 'data' => ['key1' => 'value1']];
+        $this->assertSame($payload, $result->payload);
+    }
+}

--- a/tests/RedisHandlerTest.php
+++ b/tests/RedisHandlerTest.php
@@ -117,39 +117,6 @@ final class RedisHandlerTest extends TestCase
         $this->assertSame(['key' => 'value'], $queueJob->payload['data']);
     }
 
-    /**
-     * @throws ReflectionException
-     */
-    public function testPushAndPopWithDelay(): void
-    {
-        Time::setTestNow('2023-12-29 14:15:16');
-
-        $handler = new RedisHandler($this->config);
-        $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key1' => 'value1']);
-
-        $this->assertTrue($result);
-
-        $result = $handler->push('queue-delay', 'success', ['key2' => 'value2']);
-
-        $this->assertTrue($result);
-
-        $result = $handler->pop('queue-delay', ['default']);
-        $this->assertInstanceOf(QueueJob::class, $result);
-        $payload = ['job' => 'success', 'data' => ['key2' => 'value2']];
-        $this->assertSame($payload, $result->payload);
-
-        $result = $handler->pop('queue-delay', ['default']);
-        $this->assertNull($result);
-
-        // add 1 minute
-        Time::setTestNow('2023-12-29 14:16:16');
-
-        $result = $handler->pop('queue-delay', ['default']);
-        $this->assertInstanceOf(QueueJob::class, $result);
-        $payload = ['job' => 'success', 'data' => ['key1' => 'value1']];
-        $this->assertSame($payload, $result->payload);
-    }
-
     public function testPushException(): void
     {
         $this->expectException(QueueException::class);

--- a/tests/RedisHandlerTest.php
+++ b/tests/RedisHandlerTest.php
@@ -19,6 +19,7 @@ use CodeIgniter\Queue\Exceptions\QueueException;
 use CodeIgniter\Queue\Handlers\RedisHandler;
 use CodeIgniter\Test\ReflectionHelper;
 use Exception;
+use ReflectionException;
 use Tests\Support\Config\Queue as QueueConfig;
 use Tests\Support\Database\Seeds\TestRedisQueueSeeder;
 use Tests\Support\TestCase;
@@ -93,6 +94,60 @@ final class RedisHandlerTest extends TestCase
         $queueJob = new QueueJob(json_decode((string) $task[0], true));
         $this->assertSame('success', $queueJob->payload['job']);
         $this->assertSame(['key' => 'value'], $queueJob->payload['data']);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testPushWithDelay(): void
+    {
+        Time::setTestNow('2023-12-29 14:15:16');
+
+        $handler = new RedisHandler($this->config);
+        $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
+
+        $this->assertTrue($result);
+
+        $redis = self::getPrivateProperty($handler, 'redis');
+        $this->assertSame(1, $redis->zCard('queues:queue-delay:default'));
+
+        $task     = $redis->zRangeByScore('queues:queue-delay:default', '-inf', Time::now()->addSeconds(MINUTE)->timestamp, ['limit' => [0, 1]]);
+        $queueJob = new QueueJob(json_decode((string) $task[0], true));
+        $this->assertSame('success', $queueJob->payload['job']);
+        $this->assertSame(['key' => 'value'], $queueJob->payload['data']);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testPushAndPopWithDelay(): void
+    {
+        Time::setTestNow('2023-12-29 14:15:16');
+
+        $handler = new RedisHandler($this->config);
+        $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key1' => 'value1']);
+
+        $this->assertTrue($result);
+
+        $result = $handler->push('queue-delay', 'success', ['key2' => 'value2']);
+
+        $this->assertTrue($result);
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertInstanceOf(QueueJob::class, $result);
+        $payload = ['job' => 'success', 'data' => ['key2' => 'value2']];
+        $this->assertSame($payload, $result->payload);
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertNull($result);
+
+        // add 1 minute
+        Time::setTestNow('2023-12-29 14:16:16');
+
+        $result = $handler->pop('queue-delay', ['default']);
+        $this->assertInstanceOf(QueueJob::class, $result);
+        $payload = ['job' => 'success', 'data' => ['key1' => 'value1']];
+        $this->assertSame($payload, $result->payload);
     }
 
     public function testPushException(): void


### PR DESCRIPTION
**Description**
This PR adds an option to delay job execution when adding to the queue.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
