### PR TITLE
fix: remove option to use a custom config file via service

### DIFF
--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -20,14 +20,14 @@ use CodeIgniter\Queue\Queue;
 
 class Services extends BaseService
 {
-    public static function queue(?QueueConfig $config = null, $getShared = true): QueueInterface
+    public static function queue($getShared = true): QueueInterface
     {
         if ($getShared) {
-            return static::getSharedInstance('queue', $config);
+            return static::getSharedInstance('queue');
         }
 
-        /** @var QueueConfig|null $config */
-        $config ??= config('Queue');
+        /** @var QueueConfig $config */
+        $config = config('Queue');
 
         return (new Queue($config))->init();
     }


### PR DESCRIPTION
**Description**
This PR removes the ability to define a custom config file for the queue (when using `service()`). From now on, configuration will rely exclusively on `config('Queue')`. If any changes are needed after publishing the config, they can be made manually or through a `Registrar`.

The queue worker didn’t work with custom config files, and supporting them introduced unnecessary complexity. Sticking to a single config file (similar to how `Tasks` are handled) offers a cleaner and more predictable approach.

Fixes #57

An alternative PR, which implements custom config file support: #58

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
