### PR TITLE
feat: `Queue::push()` to return QueuePushResult instead of boolean

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -160,6 +160,12 @@ service('queue')->push('emails', 'email', ['message' => 'Email message goes here
 
 We will be pushing `email` job to the `emails` queue.
 
+As a result of calling the `push()` method, you will receive a `QueuePushResult` object, which you can inspect if needed. It provides the following information:
+
+- `getStatus()`: Indicates whether the job was successfully added to the queue.
+- `getJobId()`: Returns the ID of the job that was added to the queue.
+- `getError()`: Returns any error that occurred if the job was not added.
+
 ### Sending chained jobs to the queue
 
 Sending chained jobs is also simple and lets you specify the particular order of the job execution.
@@ -172,8 +178,10 @@ service('queue')->chain(function($chain) {
 });
 ```
 
-In the example above, we will send jobs to the `reports` and `emails` queue. First, we will generate a report for given user with the `generate-report` job, after this, we will send an email with `email` job.
+In the example above, we will send jobs to the `reports` and `emails` queues. First, we will generate a report for given user with the `generate-report` job, after this, we will send an email with `email` job.
 The `email` job will be executed only if the `generate-report` job was successful.
+
+As with the `push()` method, calling the `chain()` method also returns a `QueuePushResult` object.
 
 ### Consuming the queue
 

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -22,6 +22,7 @@ use CodeIgniter\Queue\Exceptions\QueueException;
 use CodeIgniter\Queue\Models\QueueJobFailedModel;
 use CodeIgniter\Queue\Payloads\ChainBuilder;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
+use CodeIgniter\Queue\QueuePushResult;
 use CodeIgniter\Queue\Traits\HasQueueValidation;
 use ReflectionException;
 use Throwable;
@@ -39,7 +40,7 @@ abstract class BaseHandler
 
     abstract public function name(): string;
 
-    abstract public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): ?string;
+    abstract public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): QueuePushResult;
 
     abstract public function pop(string $queue, array $priorities): ?QueueJob;
 
@@ -153,7 +154,7 @@ abstract class BaseHandler
      *
      * @param Closure $callback Chain definition callback
      */
-    public function chain(Closure $callback): ?string
+    public function chain(Closure $callback): QueuePushResult
     {
         $chainBuilder = new ChainBuilder($this);
         $callback($chainBuilder);

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -39,7 +39,7 @@ abstract class BaseHandler
 
     abstract public function name(): string;
 
-    abstract public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): bool;
+    abstract public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): ?string;
 
     abstract public function pop(string $queue, array $priorities): ?QueueJob;
 
@@ -153,7 +153,7 @@ abstract class BaseHandler
      *
      * @param Closure $callback Chain definition callback
      */
-    public function chain(Closure $callback): bool
+    public function chain(Closure $callback): ?string
     {
         $chainBuilder = new ChainBuilder($this);
         $callback($chainBuilder);

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -47,7 +47,7 @@ class DatabaseHandler extends BaseHandler implements QueueInterface
      *
      * @throws ReflectionException
      */
-    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): bool
+    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): ?string
     {
         $this->validateJobAndPriority($queue, $job);
 
@@ -62,7 +62,9 @@ class DatabaseHandler extends BaseHandler implements QueueInterface
 
         $this->priority = $this->delay = null;
 
-        return $this->jobModel->insert($queueJob, false);
+        $jobId = $this->jobModel->insert($queueJob);
+
+        return $jobId !== 0 ? (string) $jobId : null;
     }
 
     /**

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -21,6 +21,7 @@ use CodeIgniter\Queue\Interfaces\QueueInterface;
 use CodeIgniter\Queue\Models\QueueJobModel;
 use CodeIgniter\Queue\Payloads\Payload;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
+use CodeIgniter\Queue\QueuePushResult;
 use ReflectionException;
 use Throwable;
 
@@ -44,10 +45,8 @@ class DatabaseHandler extends BaseHandler implements QueueInterface
 
     /**
      * Add job to the queue.
-     *
-     * @throws ReflectionException
      */
-    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): ?string
+    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): QueuePushResult
     {
         $this->validateJobAndPriority($queue, $job);
 
@@ -62,9 +61,17 @@ class DatabaseHandler extends BaseHandler implements QueueInterface
 
         $this->priority = $this->delay = null;
 
-        $jobId = $this->jobModel->insert($queueJob);
+        try {
+            $jobId = $this->jobModel->insert($queueJob);
+        } catch (Throwable $e) {
+            return QueuePushResult::failure($e->getMessage());
+        }
 
-        return $jobId !== 0 ? (string) $jobId : null;
+        if ($jobId === 0) {
+            return QueuePushResult::failure('Failed to insert job into the database.');
+        }
+
+        return QueuePushResult::success($jobId);
     }
 
     /**

--- a/src/Handlers/PredisHandler.php
+++ b/src/Handlers/PredisHandler.php
@@ -59,7 +59,7 @@ class PredisHandler extends BaseHandler implements QueueInterface
     /**
      * Add job to the queue.
      */
-    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): bool
+    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): ?string
     {
         $this->validateJobAndPriority($queue, $job);
 
@@ -67,8 +67,10 @@ class PredisHandler extends BaseHandler implements QueueInterface
 
         $availableAt = Time::now()->addSeconds($this->delay ?? 0);
 
+        $jobId = random_string('numeric', 16);
+
         $queueJob = new QueueJob([
-            'id'           => random_string('numeric', 16),
+            'id'           => $jobId,
             'queue'        => $queue,
             'payload'      => new Payload($job, $data, $metadata),
             'priority'     => $this->priority,
@@ -81,7 +83,7 @@ class PredisHandler extends BaseHandler implements QueueInterface
 
         $this->priority = $this->delay = null;
 
-        return $result > 0;
+        return $result > 0 ? $jobId : null;
     }
 
     /**

--- a/src/Handlers/PredisHandler.php
+++ b/src/Handlers/PredisHandler.php
@@ -65,9 +65,8 @@ class PredisHandler extends BaseHandler implements QueueInterface
 
         helper('text');
 
+        $jobId       = random_string('numeric', 16);
         $availableAt = Time::now()->addSeconds($this->delay ?? 0);
-
-        $jobId = random_string('numeric', 16);
 
         $queueJob = new QueueJob([
             'id'           => $jobId,

--- a/src/Handlers/PredisHandler.php
+++ b/src/Handlers/PredisHandler.php
@@ -22,6 +22,7 @@ use CodeIgniter\Queue\Enums\Status;
 use CodeIgniter\Queue\Interfaces\QueueInterface;
 use CodeIgniter\Queue\Payloads\Payload;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
+use CodeIgniter\Queue\QueuePushResult;
 use Exception;
 use Predis\Client;
 use Throwable;
@@ -59,13 +60,13 @@ class PredisHandler extends BaseHandler implements QueueInterface
     /**
      * Add job to the queue.
      */
-    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): ?string
+    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): QueuePushResult
     {
         $this->validateJobAndPriority($queue, $job);
 
         helper('text');
 
-        $jobId       = random_string('numeric', 16);
+        $jobId       = (int) random_string('numeric', 16);
         $availableAt = Time::now()->addSeconds($this->delay ?? 0);
 
         $queueJob = new QueueJob([
@@ -78,11 +79,19 @@ class PredisHandler extends BaseHandler implements QueueInterface
             'available_at' => $availableAt,
         ]);
 
-        $result = $this->predis->zadd("queues:{$queue}:{$this->priority}", [json_encode($queueJob) => $availableAt->timestamp]);
+        try {
+            $result = $this->predis->zadd("queues:{$queue}:{$this->priority}", [json_encode($queueJob) => $availableAt->timestamp]);
+        } catch (Throwable $e) {
+            return QueuePushResult::failure('Unexpected Redis error: ' . $e->getMessage());
+        } finally {
+            $this->priority = $this->delay = null;
+        }
 
         $this->priority = $this->delay = null;
 
-        return $result > 0 ? $jobId : null;
+        return $result > 0
+            ? QueuePushResult::success($jobId)
+            : QueuePushResult::failure('Job already exists in the queue.');
     }
 
     /**

--- a/src/Handlers/RedisHandler.php
+++ b/src/Handlers/RedisHandler.php
@@ -76,7 +76,7 @@ class RedisHandler extends BaseHandler implements QueueInterface
      *
      * @throws RedisException
      */
-    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): bool
+    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): ?string
     {
         $this->validateJobAndPriority($queue, $job);
 
@@ -84,8 +84,10 @@ class RedisHandler extends BaseHandler implements QueueInterface
 
         $availableAt = Time::now()->addSeconds($this->delay ?? 0);
 
+        $jobId = random_string('numeric', 16);
+
         $queueJob = new QueueJob([
-            'id'           => random_string('numeric', 16),
+            'id'           => $jobId,
             'queue'        => $queue,
             'payload'      => new Payload($job, $data, $metadata),
             'priority'     => $this->priority,
@@ -98,7 +100,7 @@ class RedisHandler extends BaseHandler implements QueueInterface
 
         $this->priority = $this->delay = null;
 
-        return $result > 0;
+        return $result > 0 ? $jobId : null;
     }
 
     /**

--- a/src/Handlers/RedisHandler.php
+++ b/src/Handlers/RedisHandler.php
@@ -22,6 +22,7 @@ use CodeIgniter\Queue\Enums\Status;
 use CodeIgniter\Queue\Interfaces\QueueInterface;
 use CodeIgniter\Queue\Payloads\Payload;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
+use CodeIgniter\Queue\QueuePushResult;
 use Redis;
 use RedisException;
 use Throwable;
@@ -76,14 +77,14 @@ class RedisHandler extends BaseHandler implements QueueInterface
      *
      * @throws RedisException
      */
-    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): ?string
+    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): QueuePushResult
     {
         $this->validateJobAndPriority($queue, $job);
 
         helper('text');
 
         $availableAt = Time::now()->addSeconds($this->delay ?? 0);
-        $jobId       = random_string('numeric', 16);
+        $jobId       = (int) random_string('numeric', 16);
 
         $queueJob = new QueueJob([
             'id'           => $jobId,
@@ -95,11 +96,21 @@ class RedisHandler extends BaseHandler implements QueueInterface
             'available_at' => $availableAt,
         ]);
 
-        $result = (int) $this->redis->zAdd("queues:{$queue}:{$this->priority}", $availableAt->timestamp, json_encode($queueJob));
+        try {
+            $result = $this->redis->zAdd("queues:{$queue}:{$this->priority}", $availableAt->timestamp, json_encode($queueJob));
+        } catch (Throwable $e) {
+            return QueuePushResult::failure('Unexpected Redis error: ' . $e->getMessage());
+        } finally {
+            $this->priority = $this->delay = null;
+        }
 
-        $this->priority = $this->delay = null;
+        if ($result === false) {
+            return QueuePushResult::failure('Failed to add job to Redis.');
+        }
 
-        return $result > 0 ? $jobId : null;
+        return (int) $result > 0
+            ? QueuePushResult::success($jobId)
+            : QueuePushResult::failure('Job already exists in the queue.');
     }
 
     /**

--- a/src/Handlers/RedisHandler.php
+++ b/src/Handlers/RedisHandler.php
@@ -83,8 +83,7 @@ class RedisHandler extends BaseHandler implements QueueInterface
         helper('text');
 
         $availableAt = Time::now()->addSeconds($this->delay ?? 0);
-
-        $jobId = random_string('numeric', 16);
+        $jobId       = random_string('numeric', 16);
 
         $queueJob = new QueueJob([
             'id'           => $jobId,

--- a/src/Payloads/ChainBuilder.php
+++ b/src/Payloads/ChainBuilder.php
@@ -44,10 +44,10 @@ class ChainBuilder
     /**
      * Dispatch the chain of jobs
      */
-    public function dispatch(): bool
+    public function dispatch(): ?string
     {
         if ($this->payloads->count() === 0) {
-            return true;
+            return null;
         }
 
         $current  = $this->payloads->shift();

--- a/src/Payloads/ChainBuilder.php
+++ b/src/Payloads/ChainBuilder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Queue\Payloads;
 
 use CodeIgniter\Queue\Handlers\BaseHandler;
+use CodeIgniter\Queue\QueuePushResult;
 
 class ChainBuilder
 {
@@ -44,10 +45,10 @@ class ChainBuilder
     /**
      * Dispatch the chain of jobs
      */
-    public function dispatch(): ?string
+    public function dispatch(): QueuePushResult
     {
         if ($this->payloads->count() === 0) {
-            return null;
+            return QueuePushResult::failure('No jobs to dispatch.');
         }
 
         $current  = $this->payloads->shift();

--- a/src/QueuePushResult.php
+++ b/src/QueuePushResult.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Queue;
 
+/**
+ * Represents the result of a queue push operation.
+ */
 class QueuePushResult
 {
     public function __construct(
@@ -22,26 +25,41 @@ class QueuePushResult
     ) {
     }
 
+    /**
+     * Creates a successful push result.
+     */
     public static function success(int $jobId): self
     {
         return new self(true, $jobId);
     }
 
+    /**
+     * Creates a failed push result.
+     */
     public static function failure(?string $error = null): self
     {
         return new self(false, null, $error);
     }
 
+    /**
+     * Returns whether the push operation was successful.
+     */
     public function getStatus(): bool
     {
         return $this->success;
     }
 
+    /**
+     * Returns the job ID if the push was successful, null otherwise.
+     */
     public function getJobId(): ?int
     {
         return $this->jobId;
     }
 
+    /**
+     * Returns the error message if the push failed, null otherwise.
+     */
     public function getError(): ?string
     {
         return $this->error;

--- a/src/QueuePushResult.php
+++ b/src/QueuePushResult.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Queue.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Queue;
+
+class QueuePushResult
+{
+    public function __construct(
+        protected readonly bool $success,
+        protected readonly ?int $jobId = null,
+        protected readonly ?string $error = null,
+    ) {
+    }
+
+    public static function success(int $jobId): self
+    {
+        return new self(true, $jobId);
+    }
+
+    public static function failure(?string $error = null): self
+    {
+        return new self(false, null, $error);
+    }
+
+    public function getStatus(): bool
+    {
+        return $this->success;
+    }
+
+    public function getJobId(): ?int
+    {
+        return $this->jobId;
+    }
+
+    public function getError(): ?string
+    {
+        return $this->error;
+    }
+}

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -85,7 +85,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler = new DatabaseHandler($this->config);
         $result  = $handler->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key' => 'value'], 'metadata' => []]),
@@ -103,7 +103,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler = new DatabaseHandler($this->config);
         $result  = $handler->setPriority('high')->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key' => 'value'], 'metadata' => []]),
@@ -122,7 +122,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler = new DatabaseHandler($this->config);
         $result  = $handler->push('queue', 'success', ['key1' => 'value1']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key1' => 'value1'], 'metadata' => []]),
@@ -132,7 +132,7 @@ final class DatabaseHandlerTest extends TestCase
 
         $result = $handler->setPriority('high')->push('queue', 'success', ['key2' => 'value2']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key2' => 'value2'], 'metadata' => []]),
@@ -161,7 +161,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler = new DatabaseHandler($this->config);
         $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $availableAt = 1703859376;
 
@@ -188,7 +188,7 @@ final class DatabaseHandlerTest extends TestCase
                 ->push('queue', 'success', ['key2' => 'value2']);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue',
             'payload' => json_encode([
@@ -221,7 +221,7 @@ final class DatabaseHandlerTest extends TestCase
                 ->setDelay(120);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue',
             'payload' => json_encode([

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -85,7 +85,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler = new DatabaseHandler($this->config);
         $result  = $handler->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key' => 'value'], 'metadata' => []]),
@@ -103,7 +103,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler = new DatabaseHandler($this->config);
         $result  = $handler->setPriority('high')->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key' => 'value'], 'metadata' => []]),
@@ -122,7 +122,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler = new DatabaseHandler($this->config);
         $result  = $handler->push('queue', 'success', ['key1' => 'value1']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key1' => 'value1'], 'metadata' => []]),
@@ -132,7 +132,7 @@ final class DatabaseHandlerTest extends TestCase
 
         $result = $handler->setPriority('high')->push('queue', 'success', ['key2' => 'value2']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'        => 'queue',
             'payload'      => json_encode(['job' => 'success', 'data' => ['key2' => 'value2'], 'metadata' => []]),
@@ -161,7 +161,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler = new DatabaseHandler($this->config);
         $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $availableAt = 1703859376;
 
@@ -188,7 +188,7 @@ final class DatabaseHandlerTest extends TestCase
                 ->push('queue', 'success', ['key2' => 'value2']);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue',
             'payload' => json_encode([
@@ -221,7 +221,7 @@ final class DatabaseHandlerTest extends TestCase
                 ->setDelay(120);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue',
             'payload' => json_encode([

--- a/tests/Payloads/ChainBuilderTest.php
+++ b/tests/Payloads/ChainBuilderTest.php
@@ -63,7 +63,7 @@ final class ChainBuilderTest extends TestCase
             $chain->push('queue', 'success', ['key' => 'value']);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue',
             'payload' => json_encode([
@@ -84,7 +84,7 @@ final class ChainBuilderTest extends TestCase
             // No jobs added
         });
 
-        $this->assertTrue($result);
+        $this->assertNull($result);
         $this->seeInDatabase('queue_jobs', []);
     }
 
@@ -99,7 +99,7 @@ final class ChainBuilderTest extends TestCase
                 ->push('queue2', 'success', ['key2' => 'value2']);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue1',
             'payload' => json_encode([
@@ -132,7 +132,7 @@ final class ChainBuilderTest extends TestCase
                 ->push('queue', 'success', ['key3' => 'value3']);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue',
             'payload' => json_encode([

--- a/tests/Payloads/ChainBuilderTest.php
+++ b/tests/Payloads/ChainBuilderTest.php
@@ -63,7 +63,7 @@ final class ChainBuilderTest extends TestCase
             $chain->push('queue', 'success', ['key' => 'value']);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue',
             'payload' => json_encode([
@@ -84,7 +84,7 @@ final class ChainBuilderTest extends TestCase
             // No jobs added
         });
 
-        $this->assertNull($result);
+        $this->assertFalse($result->getStatus());
         $this->seeInDatabase('queue_jobs', []);
     }
 
@@ -99,7 +99,7 @@ final class ChainBuilderTest extends TestCase
                 ->push('queue2', 'success', ['key2' => 'value2']);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue1',
             'payload' => json_encode([
@@ -132,7 +132,7 @@ final class ChainBuilderTest extends TestCase
                 ->push('queue', 'success', ['key3' => 'value3']);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
         $this->seeInDatabase('queue_jobs', [
             'queue'   => 'queue',
             'payload' => json_encode([

--- a/tests/PredisHandlerTest.php
+++ b/tests/PredisHandlerTest.php
@@ -72,7 +72,7 @@ final class PredisHandlerTest extends TestCase
         $handler = new PredisHandler($this->config);
         $result  = $handler->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->zcard('queues:queue:low'));
@@ -92,7 +92,7 @@ final class PredisHandlerTest extends TestCase
         $handler = new PredisHandler($this->config);
         $result  = $handler->setPriority('high')->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->zcard('queues:queue:high'));
@@ -114,7 +114,7 @@ final class PredisHandlerTest extends TestCase
         $handler = new PredisHandler($this->config);
         $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->zcard('queues:queue-delay:default'));
@@ -140,7 +140,7 @@ final class PredisHandlerTest extends TestCase
                 ->push('queue', 'success', ['key2' => 'value2']);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->zcard('queues:queue:low'));
@@ -180,7 +180,7 @@ final class PredisHandlerTest extends TestCase
                 ->setDelay(120);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $predis = self::getPrivateProperty($handler, 'predis');
         // Should be in high priority queue

--- a/tests/PredisHandlerTest.php
+++ b/tests/PredisHandlerTest.php
@@ -72,7 +72,7 @@ final class PredisHandlerTest extends TestCase
         $handler = new PredisHandler($this->config);
         $result  = $handler->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->zcard('queues:queue:low'));
@@ -92,7 +92,7 @@ final class PredisHandlerTest extends TestCase
         $handler = new PredisHandler($this->config);
         $result  = $handler->setPriority('high')->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->zcard('queues:queue:high'));
@@ -114,7 +114,7 @@ final class PredisHandlerTest extends TestCase
         $handler = new PredisHandler($this->config);
         $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->zcard('queues:queue-delay:default'));
@@ -140,7 +140,7 @@ final class PredisHandlerTest extends TestCase
                 ->push('queue', 'success', ['key2' => 'value2']);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->zcard('queues:queue:low'));
@@ -180,7 +180,7 @@ final class PredisHandlerTest extends TestCase
                 ->setDelay(120);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $predis = self::getPrivateProperty($handler, 'predis');
         // Should be in high priority queue

--- a/tests/PushAndPopWithDelayTest.php
+++ b/tests/PushAndPopWithDelayTest.php
@@ -64,11 +64,11 @@ final class PushAndPopWithDelayTest extends TestCase
         $handler = new $class($this->config);
         $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key1' => 'value1']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $result = $handler->push('queue-delay', 'success', ['key2' => 'value2']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         if ($name === 'database') {
             $this->seeInDatabase('queue_jobs', [

--- a/tests/QueuePushResultTest.php
+++ b/tests/QueuePushResultTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Queue.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests;
+
+use CodeIgniter\Queue\QueuePushResult;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class QueuePushResultTest extends TestCase
+{
+    public function testConstructorSuccess(): void
+    {
+        $result = new QueuePushResult(true, 123456, null);
+
+        $this->assertTrue($result->getStatus());
+        $this->assertSame(123456, $result->getJobId());
+        $this->assertNull($result->getError());
+    }
+
+    public function testConstructorFailure(): void
+    {
+        $result = new QueuePushResult(false, null, 'Something went wrong');
+
+        $this->assertFalse($result->getStatus());
+        $this->assertNull($result->getJobId());
+        $this->assertSame('Something went wrong', $result->getError());
+    }
+
+    public function testStaticSuccess(): void
+    {
+        $result = QueuePushResult::success(999888);
+
+        $this->assertTrue($result->getStatus());
+        $this->assertSame(999888, $result->getJobId());
+        $this->assertNull($result->getError());
+    }
+
+    public function testStaticFailure(): void
+    {
+        $result = QueuePushResult::failure('Redis error');
+
+        $this->assertFalse($result->getStatus());
+        $this->assertNull($result->getJobId());
+        $this->assertSame('Redis error', $result->getError());
+    }
+
+    public function testStaticFailureWithoutError(): void
+    {
+        $result = QueuePushResult::failure();
+
+        $this->assertFalse($result->getStatus());
+        $this->assertNull($result->getJobId());
+        $this->assertNull($result->getError());
+    }
+}

--- a/tests/RedisHandlerTest.php
+++ b/tests/RedisHandlerTest.php
@@ -69,7 +69,7 @@ final class RedisHandlerTest extends TestCase
         $handler = new RedisHandler($this->config);
         $result  = $handler->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(1, $redis->zCard('queues:queue:low'));
@@ -86,7 +86,7 @@ final class RedisHandlerTest extends TestCase
         $handler = new RedisHandler($this->config);
         $result  = $handler->setPriority('high')->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(1, $redis->zCard('queues:queue:high'));
@@ -108,7 +108,7 @@ final class RedisHandlerTest extends TestCase
         $handler = new RedisHandler($this->config);
         $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(1, $redis->zCard('queues:queue-delay:default'));
@@ -134,7 +134,7 @@ final class RedisHandlerTest extends TestCase
                 ->push('queue', 'success', ['key2' => 'value2']);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(1, $redis->zCard('queues:queue:low'));
@@ -174,7 +174,7 @@ final class RedisHandlerTest extends TestCase
                 ->setDelay(120);
         });
 
-        $this->assertNotNull($result);
+        $this->assertTrue($result->getStatus());
 
         $redis = self::getPrivateProperty($handler, 'redis');
         // Should be in high priority queue

--- a/tests/RedisHandlerTest.php
+++ b/tests/RedisHandlerTest.php
@@ -69,7 +69,7 @@ final class RedisHandlerTest extends TestCase
         $handler = new RedisHandler($this->config);
         $result  = $handler->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(1, $redis->zCard('queues:queue:low'));
@@ -86,7 +86,7 @@ final class RedisHandlerTest extends TestCase
         $handler = new RedisHandler($this->config);
         $result  = $handler->setPriority('high')->push('queue', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(1, $redis->zCard('queues:queue:high'));
@@ -108,7 +108,7 @@ final class RedisHandlerTest extends TestCase
         $handler = new RedisHandler($this->config);
         $result  = $handler->setDelay(MINUTE)->push('queue-delay', 'success', ['key' => 'value']);
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(1, $redis->zCard('queues:queue-delay:default'));
@@ -134,7 +134,7 @@ final class RedisHandlerTest extends TestCase
                 ->push('queue', 'success', ['key2' => 'value2']);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(1, $redis->zCard('queues:queue:low'));
@@ -174,7 +174,7 @@ final class RedisHandlerTest extends TestCase
                 ->setDelay(120);
         });
 
-        $this->assertTrue($result);
+        $this->assertNotNull($result);
 
         $redis = self::getPrivateProperty($handler, 'redis');
         // Should be in high priority queue


### PR DESCRIPTION
**Description**
~~This PR updates the `push()` method to return the unique job ID of the queued job instead of a simple `bool`. This allows consumers to track jobs based on their identifier.~~

This PR updates the `push()` method to return a `QueuePushResult` object instead of a simple `bool`. This change provides more detailed information about the outcome of the push operation, including the unique job ID and any error message.

* ~~`Queue::push()` now returns a `string` (job ID) on success or `null` on failure~~
* ~~Method signature updated from `bool` to `?string`~~
* This is a breaking change in method behavior
* The return type of `push()` is no longer `bool`, but a `QueuePushResult` object.
* Existing code relying on a `bool` return must be updated to check `->getStatus()` instead.


Closes #61

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
