### PR TITLE
chore: update deptrac.yaml for deptrac/deptrac

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - '**.php'
       - 'composer.*'
-      - 'depfile.yaml'
+      - 'deptrac.yaml'
       - '.github/workflows/deptrac.yml'
   push:
     branches:
@@ -15,7 +15,7 @@ on:
     paths:
       - '**.php'
       - 'composer.*'
-      - 'depfile.yaml'
+      - 'deptrac.yaml'
       - '.github/workflows/deptrac.yml'
 
 jobs:

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,4 +1,4 @@
-parameters:
+deptrac:
   paths:
     - ./src/
     - ./vendor/codeigniter4/framework/system/
@@ -153,4 +153,4 @@ parameters:
       - Vendor Entity
       - Vendor Model
       - Vendor View
-  skip_violations:
+  skip_violations: []


### PR DESCRIPTION
**Description**
This PR updates the `deptrac.yaml` configuration and the Deptrac workflow to use `deptrac.yaml` (introduced in Deptrac v2), replacing the legacy `depfile.yaml` used in v1.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
