### PR TITLE
docs: add @property tags to QueueJobFailed entity

### DIFF
--- a/src/Entities/QueueJobFailed.php
+++ b/src/Entities/QueueJobFailed.php
@@ -14,7 +14,17 @@ declare(strict_types=1);
 namespace CodeIgniter\Queue\Entities;
 
 use CodeIgniter\Entity\Entity;
+use CodeIgniter\I18n\Time;
 
+/**
+ * @property int    $id
+ * @property string $connection
+ * @property string $queue
+ * @property array  $payload
+ * @property string $priority
+ * @property string $exceptions
+ * @property Time   $failed_at
+ */
 class QueueJobFailed extends Entity
 {
     protected $dates = ['failed_at'];

--- a/src/Entities/QueueJobFailed.php
+++ b/src/Entities/QueueJobFailed.php
@@ -17,13 +17,13 @@ use CodeIgniter\Entity\Entity;
 use CodeIgniter\I18n\Time;
 
 /**
- * @property int    $id
  * @property string $connection
- * @property string $queue
- * @property array  $payload
- * @property string $priority
  * @property string $exceptions
  * @property Time   $failed_at
+ * @property int    $id
+ * @property array  $payload
+ * @property string $priority
+ * @property string $queue
  */
 class QueueJobFailed extends Entity
 {


### PR DESCRIPTION
**Description**
Contrary to the QueueJob Entity, the QueueJobFailed Entity is missing @property tags. 

This PR adds them. Thank you!

