### PR TITLE
fix: add missing methods to QueueInterface and improve type declarations

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -48,9 +48,8 @@ namespace App\Jobs;
 
 use Exception;
 use CodeIgniter\Queue\BaseJob;
-use CodeIgniter\Queue\Interfaces\JobInterface;
 
-class Email extends BaseJob implements JobInterface
+class Email extends BaseJob
 {
     /**
      * @throws Exception
@@ -94,7 +93,7 @@ If you have to use transactions in your Job - this is a simple schema you can fo
 ```php
 // ...
 
-class Email extends BaseJob implements JobInterface
+class Email extends BaseJob
 {
     /**
      * @throws Exception
@@ -130,7 +129,7 @@ We can also configure some things on the job level. It's a number of tries, when
 ```php
 // ...
 
-class Email extends BaseJob implements JobInterface
+class Email extends BaseJob
 {
     protected int $retryAfter = 60;
     protected int $tries      = 1;

--- a/src/BaseJob.php
+++ b/src/BaseJob.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Queue;
 
-abstract class BaseJob
+use CodeIgniter\Queue\Interfaces\JobInterface;
+
+abstract class BaseJob implements JobInterface
 {
     // Retry job after X seconds
     protected int $retryAfter = 60;
@@ -24,6 +26,8 @@ abstract class BaseJob
     public function __construct(protected array $data)
     {
     }
+
+    abstract public function process();
 
     public function getRetryAfter(): int
     {

--- a/src/Commands/Generators/Views/job.tpl.php
+++ b/src/Commands/Generators/Views/job.tpl.php
@@ -3,9 +3,8 @@
 namespace {namespace};
 
 use CodeIgniter\Queue\BaseJob;
-use CodeIgniter\Queue\Interfaces\JobInterface;
 
-class {class} extends BaseJob implements JobInterface
+class {class} extends BaseJob
 {
     public function process()
     {

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -19,6 +19,7 @@ use CodeIgniter\Queue\Config\Queue as QueueConfig;
 use CodeIgniter\Queue\Entities\QueueJob;
 use CodeIgniter\Queue\Entities\QueueJobFailed;
 use CodeIgniter\Queue\Exceptions\QueueException;
+use CodeIgniter\Queue\Interfaces\QueueInterface;
 use CodeIgniter\Queue\Models\QueueJobFailedModel;
 use CodeIgniter\Queue\Payloads\ChainBuilder;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
@@ -30,7 +31,7 @@ use Throwable;
 /**
  * @property QueueConfig $config
  */
-abstract class BaseHandler
+abstract class BaseHandler implements QueueInterface
 {
     use HasQueueValidation;
 

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -19,7 +19,6 @@ use CodeIgniter\Queue\Config\Queue as QueueConfig;
 use CodeIgniter\Queue\Entities\QueueJob;
 use CodeIgniter\Queue\Enums\Status;
 use CodeIgniter\Queue\Events\QueueEventManager;
-use CodeIgniter\Queue\Interfaces\QueueInterface;
 use CodeIgniter\Queue\Models\QueueJobModel;
 use CodeIgniter\Queue\Payloads\Payload;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
@@ -28,7 +27,7 @@ use ReflectionException;
 use RuntimeException;
 use Throwable;
 
-class DatabaseHandler extends BaseHandler implements QueueInterface
+class DatabaseHandler extends BaseHandler
 {
     private readonly QueueJobModel $jobModel;
 

--- a/src/Handlers/PredisHandler.php
+++ b/src/Handlers/PredisHandler.php
@@ -20,7 +20,6 @@ use CodeIgniter\Queue\Config\Queue as QueueConfig;
 use CodeIgniter\Queue\Entities\QueueJob;
 use CodeIgniter\Queue\Enums\Status;
 use CodeIgniter\Queue\Events\QueueEventManager;
-use CodeIgniter\Queue\Interfaces\QueueInterface;
 use CodeIgniter\Queue\Payloads\Payload;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
 use CodeIgniter\Queue\QueuePushResult;
@@ -29,7 +28,7 @@ use Predis\Client;
 use RuntimeException;
 use Throwable;
 
-class PredisHandler extends BaseHandler implements QueueInterface
+class PredisHandler extends BaseHandler
 {
     private readonly Client $predis;
     private readonly string $luaScript;

--- a/src/Handlers/RabbitMQHandler.php
+++ b/src/Handlers/RabbitMQHandler.php
@@ -20,7 +20,6 @@ use CodeIgniter\Queue\Entities\QueueJob;
 use CodeIgniter\Queue\Enums\Status;
 use CodeIgniter\Queue\Events\QueueEventManager;
 use CodeIgniter\Queue\Exceptions\QueueException;
-use CodeIgniter\Queue\Interfaces\QueueInterface;
 use CodeIgniter\Queue\Payloads\Payload;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
 use CodeIgniter\Queue\QueuePushResult;
@@ -32,7 +31,7 @@ use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 use Throwable;
 
-class RabbitMQHandler extends BaseHandler implements QueueInterface
+class RabbitMQHandler extends BaseHandler
 {
     private readonly AbstractConnection $connection;
     private readonly AMQPChannel $channel;

--- a/src/Handlers/RedisHandler.php
+++ b/src/Handlers/RedisHandler.php
@@ -20,7 +20,6 @@ use CodeIgniter\Queue\Config\Queue as QueueConfig;
 use CodeIgniter\Queue\Entities\QueueJob;
 use CodeIgniter\Queue\Enums\Status;
 use CodeIgniter\Queue\Events\QueueEventManager;
-use CodeIgniter\Queue\Interfaces\QueueInterface;
 use CodeIgniter\Queue\Payloads\Payload;
 use CodeIgniter\Queue\Payloads\PayloadMetadata;
 use CodeIgniter\Queue\QueuePushResult;
@@ -29,7 +28,7 @@ use RedisException;
 use RuntimeException;
 use Throwable;
 
-class RedisHandler extends BaseHandler implements QueueInterface
+class RedisHandler extends BaseHandler
 {
     private readonly Redis $redis;
     private readonly string $luaScript;

--- a/src/Interfaces/QueueInterface.php
+++ b/src/Interfaces/QueueInterface.php
@@ -13,28 +13,37 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Queue\Interfaces;
 
+use Closure;
 use CodeIgniter\Queue\Entities\QueueJob;
+use CodeIgniter\Queue\Payloads\PayloadMetadata;
+use CodeIgniter\Queue\QueuePushResult;
 use Throwable;
 
 interface QueueInterface
 {
-    public function push(string $queue, string $job, array $data);
+    public function push(string $queue, string $job, array $data, ?PayloadMetadata $metadata = null): QueuePushResult;
 
-    public function pop(string $queue, array $priorities);
+    public function pop(string $queue, array $priorities): ?QueueJob;
 
-    public function later(QueueJob $queueJob, int $seconds);
+    public function later(QueueJob $queueJob, int $seconds): bool;
 
-    public function failed(QueueJob $queueJob, Throwable $err, bool $keepJob);
+    public function failed(QueueJob $queueJob, Throwable $err, bool $keepJob): bool;
 
-    public function done(QueueJob $queueJob);
+    public function done(QueueJob $queueJob): bool;
 
-    public function clear(?string $queue = null);
+    public function clear(?string $queue = null): bool;
 
-    public function retry(?int $id, ?string $queue);
+    public function retry(?int $id, ?string $queue): int;
 
-    public function forget(int $id);
+    public function forget(int $id): bool;
 
-    public function flush(?int $hours, ?string $queue);
+    public function flush(?int $hours, ?string $queue): bool;
 
-    public function listFailed(?string $queue);
+    public function listFailed(?string $queue): array;
+
+    public function setDelay(int $delay): static;
+
+    public function setPriority(string $priority): static;
+
+    public function chain(Closure $callback): QueuePushResult;
 }

--- a/tests/_support/Jobs/Failure.php
+++ b/tests/_support/Jobs/Failure.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Tests\Support\Jobs;
 
 use CodeIgniter\Queue\BaseJob;
-use CodeIgniter\Queue\Interfaces\JobInterface;
 use Exception;
 
-class Failure extends BaseJob implements JobInterface
+class Failure extends BaseJob
 {
     /**
      * @throws Exception

--- a/tests/_support/Jobs/Success.php
+++ b/tests/_support/Jobs/Success.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
 namespace Tests\Support\Jobs;
 
 use CodeIgniter\Queue\BaseJob;
-use CodeIgniter\Queue\Interfaces\JobInterface;
 
-class Success extends BaseJob implements JobInterface
+class Success extends BaseJob
 {
     protected int $retryAfter = 6;
     protected int $tries      = 3;


### PR DESCRIPTION
**Description**
This PR fixes static analyzer errors by properly declaring all public API methods in `QueueInterface` and `JobInterface`.

- Added missing methods to `QueueInterface`: `setDelay()`, `setPriority()`, `chain()`                                                                                                
- Added complete return types to all interface methods
- Made `BaseHandler` and `BaseJob` implement their respective interfaces                                                                                                             
- Removed redundant interface declarations from child classes                                                                                                                        
- Updated generator template and docs

Fixes #74

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
