### PR TITLE
chore: update workflow to include PHP 8.5

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   deptrac:
-    uses: codeigniter4/.github/.github/workflows/deptrac.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/deptrac.yml@CI47

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.4']
+        php-versions: ['8.2', '8.5']
 
     steps:
       - name: Checkout

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,7 +38,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
         db-platforms: ['MySQLi', 'SQLite3']
         include:
           # Postgre

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.4']
+        php-versions: ['8.2', '8.5']
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Queues for the CodeIgniter 4 framework.
 [![Deptrac](https://github.com/codeigniter4/queue/actions/workflows/deptrac.yml/badge.svg)](https://github.com/codeigniter4/queue/actions/workflows/deptrac.yml)
 [![Coverage Status](https://coveralls.io/repos/github/codeigniter4/queue/badge.svg?branch=develop)](https://coveralls.io/github/codeigniter4/queue?branch=develop)
 
-![PHP](https://img.shields.io/badge/PHP-%5E8.1-blue)
+![PHP](https://img.shields.io/badge/PHP-%5E8.2-blue)
 ![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.3-blue)
 ![License](https://img.shields.io/badge/License-MIT-blue)
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "homepage": "https://github.com/codeigniter4/queue",
     "require": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "require-dev": {
         "codeigniter4/devkit": "^1.3",

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Listen for queued jobs.
 
 ### Requirements
 
-- PHP 8.1+
+- PHP 8.2+
 - CodeIgniter 4.3+
 
 If you use `database` handler:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,12 +11,6 @@ parameters:
 	    -
 	        message: '#Call to method PHPUnit\\Framework\\Assert::assertInstanceOf\(\) with.#'
 	    -
-	        message: '#Call to deprecated function random_string\(\):#'
-	        paths:
-	            - src/Handlers/RedisHandler.php
-	            - src/Handlers/PredisHandler.php
-	            - src/Handlers/RabbitMQHandler.php
-	    -
 	        message: '#Call to an undefined method CodeIgniter\\Queue\\Models\\QueueJobFailedModel::affectedRows\(\).#'
 	        paths:
 	            - src/Handlers/BaseHandler.php

--- a/src/Commands/QueueWork.php
+++ b/src/Commands/QueueWork.php
@@ -492,6 +492,8 @@ class QueueWork extends BaseCommand
 
     /**
      * Handle interruption
+     *
+     * @phpstan-ignore method.unused
      */
     private function onInterruption(int $signal): void
     {

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -70,6 +70,7 @@ abstract class BaseHandler
             )
             ->findAll();
 
+        /** @var list<QueueJobFailed> $jobs */
         foreach ($jobs as $job) {
             $this->setPriority($job->priority)->push($job->queue, $job->payload['job'], $job->payload['data']);
             $this->forget($job->id);

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -367,7 +367,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler  = new DatabaseHandler($this->config);
         $queueJob = $handler->pop('queue1', ['default']);
 
-        $err    = new Exception('Sample exception');
+        $err = new Exception('Sample exception');
         $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, true);
 
@@ -388,7 +388,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler  = new DatabaseHandler($this->config);
         $queueJob = $handler->pop('queue1', ['default']);
 
-        $err    = new Exception('Sample exception');
+        $err = new Exception('Sample exception');
         $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, false);
 
@@ -480,7 +480,7 @@ final class DatabaseHandlerTest extends TestCase
         $handler  = new DatabaseHandler($this->config);
         $queueJob = $handler->pop('queue1', ['default']);
 
-        $err    = new Exception('Sample exception here');
+        $err = new Exception('Sample exception here');
         $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, true);
 

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -345,6 +345,7 @@ final class DatabaseHandlerTest extends TestCase
             'id'     => 2,
             'status' => Status::RESERVED->value,
         ]);
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
 
         $result = $handler->later($queueJob, 60);
 
@@ -367,6 +368,7 @@ final class DatabaseHandlerTest extends TestCase
         $queueJob = $handler->pop('queue1', ['default']);
 
         $err    = new Exception('Sample exception');
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, true);
 
         $this->assertTrue($result);
@@ -387,6 +389,7 @@ final class DatabaseHandlerTest extends TestCase
         $queueJob = $handler->pop('queue1', ['default']);
 
         $err    = new Exception('Sample exception');
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, false);
 
         $this->assertTrue($result);
@@ -407,6 +410,7 @@ final class DatabaseHandlerTest extends TestCase
     {
         $handler  = new DatabaseHandler($this->config);
         $queueJob = $handler->pop('queue1', ['default']);
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
 
         $result = $handler->done($queueJob);
 
@@ -477,6 +481,7 @@ final class DatabaseHandlerTest extends TestCase
         $queueJob = $handler->pop('queue1', ['default']);
 
         $err    = new Exception('Sample exception here');
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, true);
 
         $this->assertTrue($result);

--- a/tests/PredisHandlerTest.php
+++ b/tests/PredisHandlerTest.php
@@ -281,7 +281,7 @@ final class PredisHandlerTest extends TestCase
         $handler  = new PredisHandler($this->config);
         $queueJob = $handler->pop('queue1', ['default']);
 
-        $err    = new Exception('Sample exception');
+        $err = new Exception('Sample exception');
         $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, true);
 
@@ -306,7 +306,7 @@ final class PredisHandlerTest extends TestCase
         $handler  = new PredisHandler($this->config);
         $queueJob = $handler->pop('queue1', ['default']);
 
-        $err    = new Exception('Sample exception');
+        $err = new Exception('Sample exception');
         $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, false);
 

--- a/tests/PredisHandlerTest.php
+++ b/tests/PredisHandlerTest.php
@@ -264,6 +264,7 @@ final class PredisHandlerTest extends TestCase
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(1, $predis->hexists('queues:queue1::reserved', $queueJob->id));
         $this->assertSame(0, $predis->zcard('queues:queue1:default'));
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
 
         $result = $handler->later($queueJob, 60);
 
@@ -281,6 +282,7 @@ final class PredisHandlerTest extends TestCase
         $queueJob = $handler->pop('queue1', ['default']);
 
         $err    = new Exception('Sample exception');
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, true);
 
         $predis = self::getPrivateProperty($handler, 'predis');
@@ -305,6 +307,7 @@ final class PredisHandlerTest extends TestCase
         $queueJob = $handler->pop('queue1', ['default']);
 
         $err    = new Exception('Sample exception');
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, false);
 
         $predis = self::getPrivateProperty($handler, 'predis');
@@ -330,6 +333,7 @@ final class PredisHandlerTest extends TestCase
 
         $predis = self::getPrivateProperty($handler, 'predis');
         $this->assertSame(0, $predis->zcard('queues:queue1:default'));
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
 
         $result = $handler->done($queueJob);
 

--- a/tests/RedisHandlerTest.php
+++ b/tests/RedisHandlerTest.php
@@ -252,6 +252,7 @@ final class RedisHandlerTest extends TestCase
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertTrue($redis->hExists('queues:queue1::reserved', (string) $queueJob->id));
         $this->assertSame(0, $redis->zCard('queues:queue1:default'));
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
 
         $result = $handler->later($queueJob, 60);
 
@@ -266,6 +267,7 @@ final class RedisHandlerTest extends TestCase
         $queueJob = $handler->pop('queue1', ['default']);
 
         $err    = new Exception('Sample exception');
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, true);
 
         $redis = self::getPrivateProperty($handler, 'redis');
@@ -287,6 +289,7 @@ final class RedisHandlerTest extends TestCase
         $queueJob = $handler->pop('queue1', ['default']);
 
         $err    = new Exception('Sample exception');
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, false);
 
         $redis = self::getPrivateProperty($handler, 'redis');
@@ -309,6 +312,7 @@ final class RedisHandlerTest extends TestCase
 
         $redis = self::getPrivateProperty($handler, 'redis');
         $this->assertSame(0, $redis->zCard('queues:queue1:default'));
+        $this->assertInstanceOf(QueueJob::class, $queueJob);
 
         $result = $handler->done($queueJob);
 

--- a/tests/RedisHandlerTest.php
+++ b/tests/RedisHandlerTest.php
@@ -266,7 +266,7 @@ final class RedisHandlerTest extends TestCase
         $handler  = new RedisHandler($this->config);
         $queueJob = $handler->pop('queue1', ['default']);
 
-        $err    = new Exception('Sample exception');
+        $err = new Exception('Sample exception');
         $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, true);
 
@@ -288,7 +288,7 @@ final class RedisHandlerTest extends TestCase
         $handler  = new RedisHandler($this->config);
         $queueJob = $handler->pop('queue1', ['default']);
 
-        $err    = new Exception('Sample exception');
+        $err = new Exception('Sample exception');
         $this->assertInstanceOf(QueueJob::class, $queueJob);
         $result = $handler->failed($queueJob, $err, false);
 


### PR DESCRIPTION
**Description**
This PR updates workflows to include PHP 8.5 and officially updates minimum PHP version to 8.2.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
