### PR TITLE
fix: SQLite3 queue pop atomicity

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,8 @@ The configuration settings for `database` handler.
 
     The [Strict Mode](https://codeigniter.com/user_guide/database/transactions.html#strict-mode) for the given `dbGroup` is automatically disabled - due to the nature of the queue worker.
 
+    When using **SQLite3** with multiple worker processes, configure `busyTimeout` in the selected connection group. This lets a worker wait briefly when another process holds SQLite's write lock instead of failing immediately with `SQLITE_BUSY`.
+
 ### $redis
 
 The configuration settings for `redis` handler. You need to have a [ext-redis](https://github.com/phpredis/phpredis) installed to use it.

--- a/docs/running-queues.md
+++ b/docs/running-queues.md
@@ -117,6 +117,8 @@ When using the `chain()` method, there are a few important differences compared 
 
 As mentioned above, sometimes we may want to have multiple instances of the same command running at the same time. The queue is safe to use in that scenario with all databases as long as you keep the `skipLocked` to `true` in the config file. Only for SQLite3 driver, this setting is not relevant as it provides atomicity without the need for explicit concurrency control.
 
+When using **SQLite3** with multiple worker processes, configure `busyTimeout` in the selected connection group. This lets a worker wait briefly when another process holds SQLite's write lock instead of failing immediately with `SQLITE_BUSY`.
+
 The PHPRedis and Predis drivers are also safe to use with multiple instances of the same command.
 
 ### Handling long-running process

--- a/src/Models/QueueJobModel.php
+++ b/src/Models/QueueJobModel.php
@@ -23,6 +23,7 @@ use CodeIgniter\Queue\Enums\Status;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Database;
 use ReflectionException;
+use Throwable;
 
 class QueueJobModel extends Model
 {
@@ -72,6 +73,80 @@ class QueueJobModel extends Model
             // Make sure we still have the connection
             $this->db->reconnect();
         }
+
+        return match ($this->db->DBDriver) {
+            'SQLite3' => $this->popAtomic($name, $priority),
+            default   => $this->popWithLock($name, $priority),
+        };
+    }
+
+    /**
+     * Claim the oldest pending job while holding SQLite's write lock.
+     *
+     * SQLite has no FOR UPDATE SKIP LOCKED. BEGIN IMMEDIATE takes the write
+     * lock before the SELECT, so the candidate cannot be claimed by another
+     * worker between selecting it and marking it RESERVED.
+     *
+     * @throws ReflectionException
+     */
+    private function popAtomic(string $name, array $priority): ?QueueJob
+    {
+        if ($this->db->simpleQuery('BEGIN IMMEDIATE') === false) {
+            return null;
+        }
+
+        try {
+            $builder = $this->builder()
+                ->where('queue', $name)
+                ->where('status', Status::PENDING->value)
+                ->where('available_at <=', Time::now()->timestamp)
+                ->limit(1);
+
+            $builder = $this->setPriority($builder, $priority);
+            $sql     = $builder->getCompiledSelect();
+
+            $query = $this->db->query($sql);
+
+            if ($query === false) {
+                $this->db->simpleQuery('ROLLBACK');
+
+                return null;
+            }
+
+            /** @var QueueJob|null $row */
+            $row = $query->getCustomRowObject(0, QueueJob::class);
+
+            if ($row === null) {
+                $this->db->simpleQuery('COMMIT');
+
+                return null;
+            }
+
+            $this->builder()
+                ->where('id', $row->id)
+                ->where('status', Status::PENDING->value)
+                ->update(['status' => Status::RESERVED->value]);
+
+            $claimed = $this->db->affectedRows() === 1;
+
+            $this->db->simpleQuery('COMMIT');
+
+            return $claimed ? $row : null;
+        } catch (Throwable $e) {
+            $this->db->simpleQuery('ROLLBACK');
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Claim the oldest pending job inside a transaction, using
+     * FOR UPDATE SKIP LOCKED where supported.
+     *
+     * @throws ReflectionException
+     */
+    private function popWithLock(string $name, array $priority): ?QueueJob
+    {
         // Start transaction
         $this->db->transStart();
 
@@ -87,6 +162,8 @@ class QueueJobModel extends Model
 
         $query = $this->db->query($this->skipLocked($sql));
         if ($query === false) {
+            $this->db->transComplete();
+
             return null;
         }
         /** @var QueueJob|null $row */

--- a/tests/Models/QueueJobModelTest.php
+++ b/tests/Models/QueueJobModelTest.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Tests\Models;
 
+use CodeIgniter\Queue\Entities\QueueJob;
+use CodeIgniter\Queue\Enums\Status;
 use CodeIgniter\Queue\Models\QueueJobModel;
 use CodeIgniter\Test\ReflectionHelper;
+use Tests\Support\Database\Seeds\TestDatabaseQueueSeeder;
 use Tests\Support\TestCase;
 
 /**
@@ -23,6 +26,8 @@ use Tests\Support\TestCase;
 final class QueueJobModelTest extends TestCase
 {
     use ReflectionHelper;
+
+    protected $seed = TestDatabaseQueueSeeder::class;
 
     public function testQueueJobModel(): void
     {
@@ -58,5 +63,55 @@ final class QueueJobModelTest extends TestCase
         $result = $method($sql);
 
         $this->assertSame($sql, $result);
+    }
+
+    public function testGetFromQueueReservesPendingJob(): void
+    {
+        $model = model(QueueJobModel::class);
+
+        $job = $model->getFromQueue('queue1', ['default']);
+
+        $this->assertInstanceOf(QueueJob::class, $job);
+        $this->assertSame('queue1', $job->queue);
+        $this->seeInDatabase('queue_jobs', [
+            'id'     => $job->id,
+            'status' => Status::RESERVED->value,
+        ]);
+    }
+
+    public function testGetFromQueueReturnsNullWhenNothingPending(): void
+    {
+        $model = model(QueueJobModel::class);
+
+        $this->assertNull($model->getFromQueue('queue123', ['default']));
+    }
+
+    public function testGetFromQueueOnSQLite3ClaimsEachPendingJobOnce(): void
+    {
+        $model = model(QueueJobModel::class);
+
+        if ($model->db->DBDriver !== 'SQLite3') {
+            $this->markTestSkipped('BEGIN IMMEDIATE claim is SQLite3-only.');
+        }
+
+        $model->insert(new QueueJob([
+            'queue'        => 'queue1',
+            'payload'      => ['job' => 'extra', 'data' => []],
+            'priority'     => 'default',
+            'status'       => Status::PENDING->value,
+            'attempts'     => 0,
+            'available_at' => 1_697_269_865,
+        ]));
+
+        $job1 = $model->getFromQueue('queue1', ['default']);
+        $job2 = $model->getFromQueue('queue1', ['default']);
+
+        $this->assertInstanceOf(QueueJob::class, $job1);
+        $this->assertInstanceOf(QueueJob::class, $job2);
+        $this->assertSame(2, $job1->id);
+        $this->assertSame(3, $job2->id);
+        $this->assertNull($model->getFromQueue('queue1', ['default']));
+        $this->seeInDatabase('queue_jobs', ['id' => 2, 'status' => Status::RESERVED->value]);
+        $this->seeInDatabase('queue_jobs', ['id' => 3, 'status' => Status::RESERVED->value]);
     }
 }


### PR DESCRIPTION
**Description**
This PR fixes SQLite queue popping so concurrent workers cannot claim the same pending job.

SQLite now uses `BEGIN IMMEDIATE` to acquire the write lock before selecting and reserving a job. Other database drivers keep the existing transaction and skip-locked behavior.

It also adds coverage for SQLite job claiming and documents `busyTimeout` for SQLite multi-worker setups.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
