### PR TITLE
fix: rethrow runtime errors during queue dispatch

### DIFF
--- a/src/Commands/QueueWork.php
+++ b/src/Commands/QueueWork.php
@@ -314,40 +314,19 @@ class QueueWork extends BaseCommand
         );
 
         try {
-            // Load payload metadata
-            $payloadMetadata = PayloadMetadata::fromArray($payload['metadata'] ?? []);
+            try {
+                // Load payload metadata
+                $payloadMetadata = PayloadMetadata::fromArray($payload['metadata'] ?? []);
 
-            // Renew lock if needed
-            $this->renewLock($payloadMetadata);
+                // Renew lock if needed
+                $this->renewLock($payloadMetadata);
 
-            $class = $config->resolveJobClass($payload['job']);
-            $job   = new $class($payload['data']);
-            $job->process();
-
-            // Mark as done
-            service('queue')->done($work);
-
-            // Emit job processing completed event
-            QueueEventManager::jobProcessingCompleted(
-                handler: service('queue')->name(),
-                queue: $work->queue,
-                job: $work,
-                processingTime: microtime(true) - $startTime,
-                metadata: [
-                    'worker_id' => $this->workerId,
-                ],
-            );
-
-            CLI::write('The processing of this job was successful', 'green');
-
-            // Check chained jobs
-            $this->processNextJobInChain($payloadMetadata);
-        } catch (Throwable $err) {
-            if (isset($job) && ++$work->attempts < ($tries ?? $job->getTries())) {
-                // Schedule for later
-                service('queue')->later($work, $retryAfter ?? $job->getRetryAfter());
-            } else {
-                // Mark as failed
+                $class = $config->resolveJobClass($payload['job']);
+                $job   = new $class($payload['data']);
+            } catch (Exception $err) {
+                // Mark dispatch-time exceptions as failed jobs, but allow
+                // PHP runtime errors to escape so the worker process can be
+                // recycled with fresh runtime state.
                 QueueEventManager::jobFailed(
                     handler: service('queue')->name(),
                     queue: $work->queue,
@@ -360,11 +339,58 @@ class QueueWork extends BaseCommand
                 );
 
                 service('queue')->failed($work, $err, $config->keepFailedJobs);
+                CLI::write('The processing of this job failed', 'red');
+
+                return;
             }
-            CLI::write('The processing of this job failed', 'red');
+
+            try {
+                $job->process();
+
+                // Mark as done
+                service('queue')->done($work);
+
+                // Emit job processing completed event
+                QueueEventManager::jobProcessingCompleted(
+                    handler: service('queue')->name(),
+                    queue: $work->queue,
+                    job: $work,
+                    processingTime: microtime(true) - $startTime,
+                    metadata: [
+                        'worker_id' => $this->workerId,
+                    ],
+                );
+
+                CLI::write('The processing of this job was successful', 'green');
+
+                // Check chained jobs
+                $this->processNextJobInChain($payloadMetadata);
+            } catch (Throwable $err) {
+                if (isset($job) && ++$work->attempts < ($tries ?? $job->getTries())) {
+                    // Schedule for later
+                    service('queue')->later($work, $retryAfter ?? $job->getRetryAfter());
+                } else {
+                    // Mark as failed
+                    QueueEventManager::jobFailed(
+                        handler: service('queue')->name(),
+                        queue: $work->queue,
+                        job: $work,
+                        exception: $err,
+                        processingTime: microtime(true) - $startTime,
+                        metadata: [
+                            'worker_id' => $this->workerId,
+                        ],
+                    );
+
+                    service('queue')->failed($work, $err, $config->keepFailedJobs);
+                }
+                CLI::write('The processing of this job failed', 'red');
+            }
         } finally {
             // Remove lock if needed
-            $this->clearLock($payloadMetadata);
+            if ($payloadMetadata instanceof PayloadMetadata) {
+                $this->clearLock($payloadMetadata);
+            }
 
             timer()->stop('work');
             CLI::write(sprintf('It took: %s sec', timer()->getElapsedTime('work')) . PHP_EOL, 'cyan');

--- a/tests/Commands/QueueWorkTest.php
+++ b/tests/Commands/QueueWorkTest.php
@@ -18,6 +18,7 @@ use CodeIgniter\Config\Services;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Queue\Models\QueueJobModel;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Error;
 use Tests\Support\CLITestCase;
 
 /**
@@ -82,6 +83,67 @@ final class QueueWorkTest extends CLITestCase
 
         $this->assertSame('Listening for the jobs with the queue: test', $this->getLine(0));
         $this->assertSame('Starting a new job: failure, with ID: 1', $this->getLine(3));
+        $this->assertSame('The processing of this job failed', $this->getLine(4));
+        $this->assertSame('No job available. Stopping.', $this->getLine(7));
+    }
+
+    public function testRunRethrowsRuntimeErrorDuringJobDispatch(): void
+    {
+        Time::setTestNow('2023-12-19 14:15:16');
+
+        fake(QueueJobModel::class, [
+            'connection'   => 'database',
+            'queue'        => 'test',
+            'payload'      => ['job' => 'constructor-runtime-error', 'data' => ['key' => 'value']],
+            'priority'     => 'default',
+            'status'       => 0,
+            'attempts'     => 0,
+            'available_at' => 1_702_977_074,
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+        $outputBufferLevel = ob_get_level();
+
+        try {
+            command('queue:work test sleep 1 --stop-when-empty');
+
+            $this->fail('Expected dispatch-time runtime errors to bubble out of queue:work.');
+        } catch (Error $error) {
+            $this->assertSame('Runtime error during job construction.', $error->getMessage());
+        } finally {
+            while (ob_get_level() > $outputBufferLevel) {
+                ob_end_clean();
+            }
+
+            CITestStreamFilter::removeOutputFilter();
+        }
+    }
+
+    public function testRunRecordsTypeErrorThrownDuringJobProcessing(): void
+    {
+        Time::setTestNow('2023-12-19 14:15:16');
+
+        fake(QueueJobModel::class, [
+            'connection'   => 'database',
+            'queue'        => 'test',
+            'payload'      => ['job' => 'process-type-error', 'data' => ['key' => 'value']],
+            'priority'     => 'default',
+            'status'       => 0,
+            'attempts'     => 0,
+            'available_at' => 1_702_977_074,
+        ]);
+
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+
+        $this->assertNotFalse(command('queue:work test sleep 1 --stop-when-empty'));
+        $this->parseOutput(CITestStreamFilter::$buffer);
+
+        CITestStreamFilter::removeOutputFilter();
+
+        $this->assertSame('Listening for the jobs with the queue: test', $this->getLine(0));
+        $this->assertSame('Starting a new job: process-type-error, with ID: 1', $this->getLine(3));
         $this->assertSame('The processing of this job failed', $this->getLine(4));
         $this->assertSame('No job available. Stopping.', $this->getLine(7));
     }

--- a/tests/_support/Config/Queue.php
+++ b/tests/_support/Config/Queue.php
@@ -18,7 +18,9 @@ use CodeIgniter\Queue\Handlers\DatabaseHandler;
 use CodeIgniter\Queue\Handlers\PredisHandler;
 use CodeIgniter\Queue\Handlers\RabbitMQHandler;
 use CodeIgniter\Queue\Handlers\RedisHandler;
+use Tests\Support\Jobs\ConstructorError;
 use Tests\Support\Jobs\Failure;
+use Tests\Support\Jobs\ProcessTypeError;
 use Tests\Support\Jobs\Success;
 
 class Queue extends BaseQueue
@@ -112,7 +114,9 @@ class Queue extends BaseQueue
      * Your jobs handlers.
      */
     public array $jobHandlers = [
-        'success' => Success::class,
-        'failure' => Failure::class,
+        'success'                   => Success::class,
+        'failure'                   => Failure::class,
+        'constructor-runtime-error' => ConstructorError::class,
+        'process-type-error'        => ProcessTypeError::class,
     ];
 }

--- a/tests/_support/Jobs/ConstructorError.php
+++ b/tests/_support/Jobs/ConstructorError.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Queue.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Jobs;
+
+use CodeIgniter\Queue\BaseJob;
+use Error;
+
+class ConstructorError extends BaseJob
+{
+    public function __construct(array $data)
+    {
+        parent::__construct($data);
+
+        throw new Error('Runtime error during job construction.');
+    }
+
+    public function process(): void
+    {
+    }
+}

--- a/tests/_support/Jobs/ProcessTypeError.php
+++ b/tests/_support/Jobs/ProcessTypeError.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Queue.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Jobs;
+
+use CodeIgniter\Queue\BaseJob;
+use TypeError;
+
+class ProcessTypeError extends BaseJob
+{
+    public function process(): void
+    {
+        throw new TypeError('Runtime type error during job processing.');
+    }
+}


### PR DESCRIPTION
## Summary

This PR splits `QueueWork::handleWork()` into two throwable-handling phases:

- job dispatch / construction catches `Exception` only, allowing PHP runtime `Error` instances to bubble out of the worker process
- user job `process()` execution continues to catch `Throwable`, preserving the existing failed-job behavior for per-job bugs

The motivation is a stale-runtime failure mode seen downstream: when `vendor/` is regenerated while long-lived queue workers are still running, a worker can keep an opcache-cached Composer autoloader reference to an old `ComposerAutoloaderInit...` class. The next job dispatch can then throw `Error: Class "ComposerAutoloaderInit..." not found` while constructing the job. Today that `Error` is caught by the broad `catch (Throwable)`, recorded as a failed job, and the worker stays alive with broken runtime state. Supervisors such as systemd never get a process exit to recycle.

Letting dispatch-time runtime errors escape makes the failure loud and lets the process supervisor restart the worker with fresh runtime state. Runtime errors thrown by the job's own `process()` method are still treated as per-job failures, which avoids crash loops for a buggy job implementation.

## Details

The important distinction is where the throwable originates, not just its type:

- dispatch/class resolution/construction errors happen before the worker has a usable job instance; `Error` here can indicate stale autoload/opcache or otherwise broken runtime state
- `process()` errors happen inside user job code; `Exception` and `Error` are both still recorded using the existing retry/failed-job path

This also guards lock cleanup so `clearLock()` only runs once metadata was successfully parsed.

## Tests

Added PHPUnit coverage for both sides of the split:

- dispatch-time runtime `Error` thrown during job construction bubbles out of `queue:work`
- `TypeError` thrown from `process()` is caught and recorded as a failed job, and the worker keeps going

Local verification:

```bash
vendor/bin/phpunit --no-coverage tests/Commands/QueueWorkTest.php
vendor/bin/php-cs-fixer fix --ansi --verbose --dry-run --diff --config=.php-cs-fixer.dist.php --path-mode=intersection src/Commands/QueueWork.php tests/Commands/QueueWorkTest.php tests/_support/Config/Queue.php tests/_support/Jobs/ConstructorError.php tests/_support/Jobs/ProcessTypeError.php
```

I also ran the full PHPUnit suite locally; it is not clean in my environment because Redis/Predis tests cannot connect to `127.0.0.1:6379` and three unrelated existing CLI-output whitespace assertions fail. The targeted `QueueWorkTest` suite passes.

## Known limitation

A deferred autoload failure that happens inside `process()` is still caught as a per-job failure. Escalating only those cases would require message matching or stack inspection, which seems brittle. This PR keeps the structural boundary clean: dispatch/runtime setup errors can recycle the worker; job-code errors use the existing failed-job path.
