### PR TITLE
Fix: Prevent SQL injection in QueueJobModel priority sorting

### DIFF
--- a/src/Models/QueueJobModel.php
+++ b/src/Models/QueueJobModel.php
@@ -134,12 +134,14 @@ class QueueJobModel extends Model
         $builder->whereIn('priority', $priority);
 
         if ($priority !== ['default']) {
+            $escapedPriority = array_map([$this->db, 'escape'], $priority);
+
             if ($this->db->DBDriver !== 'MySQLi') {
                 $builder->orderBy(
                     sprintf('CASE %s ', $this->db->protectIdentifiers('priority'))
                     . implode(
                         ' ',
-                        array_map(static fn ($value, $key) => "WHEN '{$value}' THEN {$key}", $priority, array_keys($priority)),
+                        array_map(static fn ($value, $key) => "WHEN {$value} THEN {$key}", $escapedPriority, array_keys($escapedPriority)),
                     )
                     . ' END',
                     '',
@@ -148,10 +150,7 @@ class QueueJobModel extends Model
             } else {
                 $builder->orderBy(
                     'FIELD(priority, '
-                    . implode(
-                        ',',
-                        array_map(static fn ($value) => "'{$value}'", $priority),
-                    )
+                    . implode(',', $escapedPriority)
                     . ')',
                     '',
                     false,

--- a/src/Models/QueueJobModel.php
+++ b/src/Models/QueueJobModel.php
@@ -131,6 +131,8 @@ class QueueJobModel extends Model
      */
     private function setPriority(BaseBuilder $builder, array $priority): BaseBuilder
     {
+        $priority = array_values($priority);
+
         $builder->whereIn('priority', $priority);
 
         if ($priority !== ['default']) {

--- a/tests/Models/QueueJobModelTest.php
+++ b/tests/Models/QueueJobModelTest.php
@@ -66,17 +66,23 @@ final class QueueJobModelTest extends TestCase
         $method  = $this->getPrivateMethodInvoker($model, 'setPriority');
         $builder = $model->builder();
 
-        $result = $method($builder, ['high', 'low']);
+        $result = $method($builder, ['key1' => 'high', 'key2' => 'low', 'key3' => "un'safe"]);
 
         $sql = $result->getCompiledSelect();
 
         $this->assertStringContainsString('priority', $sql);
+
+        $escHigh   = $model->db->escape('high');
+        $escLow    = $model->db->escape('low');
+        $escUnsafe = $model->db->escape("un'safe");
+
         if ($model->db->DBDriver === 'MySQLi') {
-            $this->assertStringContainsString('FIELD(priority, ', $sql);
+            $this->assertStringContainsString("FIELD(priority, {$escHigh}, {$escLow}, {$escUnsafe})", $sql);
         } else {
             $this->assertStringContainsString('CASE ', $sql);
-            $this->assertStringContainsString(' WHEN ', $sql);
-            $this->assertStringContainsString(' THEN ', $sql);
+            $this->assertStringContainsString("WHEN {$escHigh} THEN 0", $sql);
+            $this->assertStringContainsString("WHEN {$escLow} THEN 1", $sql);
+            $this->assertStringContainsString("WHEN {$escUnsafe} THEN 2", $sql);
             $this->assertStringContainsString(' END', $sql);
         }
     }

--- a/tests/Models/QueueJobModelTest.php
+++ b/tests/Models/QueueJobModelTest.php
@@ -59,4 +59,25 @@ final class QueueJobModelTest extends TestCase
 
         $this->assertSame($sql, $result);
     }
+
+    public function testSetPriority(): void
+    {
+        $model   = model(QueueJobModel::class);
+        $method  = $this->getPrivateMethodInvoker($model, 'setPriority');
+        $builder = $model->builder();
+
+        $result = $method($builder, ['high', 'low']);
+
+        $sql = $result->getCompiledSelect();
+
+        $this->assertStringContainsString('priority', $sql);
+        if ($model->db->DBDriver === 'MySQLi') {
+            $this->assertStringContainsString('FIELD(priority, ', $sql);
+        } else {
+            $this->assertStringContainsString('CASE ', $sql);
+            $this->assertStringContainsString(' WHEN ', $sql);
+            $this->assertStringContainsString(' THEN ', $sql);
+            $this->assertStringContainsString(' END', $sql);
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes a potential SQL injection vulnerability in the QueueJobModel by properly escaping priority values before using them in CASE and FIELD SQL statements. A unit test was also added to ensure correct behavior.