### PR TITLE
chore: harden database queue priority ordering

### DIFF
--- a/src/Models/QueueJobModel.php
+++ b/src/Models/QueueJobModel.php
@@ -208,15 +208,19 @@ class QueueJobModel extends Model
      */
     private function setPriority(BaseBuilder $builder, array $priority): BaseBuilder
     {
+        $priority = array_values($priority);
+
         $builder->whereIn('priority', $priority);
 
         if ($priority !== ['default']) {
+            $escapedPriority = array_map($this->db->escape(...), $priority);
+
             if ($this->db->DBDriver !== 'MySQLi') {
                 $builder->orderBy(
                     sprintf('CASE %s ', $this->db->protectIdentifiers('priority'))
                     . implode(
                         ' ',
-                        array_map(static fn ($value, $key) => "WHEN '{$value}' THEN {$key}", $priority, array_keys($priority)),
+                        array_map(static fn ($value, $key) => "WHEN {$value} THEN {$key}", $escapedPriority, array_keys($escapedPriority)),
                     )
                     . ' END',
                     '',
@@ -225,10 +229,7 @@ class QueueJobModel extends Model
             } else {
                 $builder->orderBy(
                     'FIELD(priority, '
-                    . implode(
-                        ',',
-                        array_map(static fn ($value) => "'{$value}'", $priority),
-                    )
+                    . implode(',', $escapedPriority)
                     . ')',
                     '',
                     false,

--- a/tests/Models/QueueJobModelTest.php
+++ b/tests/Models/QueueJobModelTest.php
@@ -129,7 +129,7 @@ final class QueueJobModelTest extends TestCase
         $result = $method($builder, $priority);
         $sql    = (string) $result->getCompiledSelect();
 
-        $this->assertStringContainsString($model->db->escape($priority['priority_key']), $sql);
-        $this->assertStringNotContainsString('priority_key', $sql);
+        $this->assertStringContainsString($model->db->escape($priority['priority_key']), (string) $sql);
+        $this->assertStringNotContainsString('priority_key', (string) $sql);
     }
 }

--- a/tests/Models/QueueJobModelTest.php
+++ b/tests/Models/QueueJobModelTest.php
@@ -114,4 +114,22 @@ final class QueueJobModelTest extends TestCase
         $this->seeInDatabase('queue_jobs', ['id' => 2, 'status' => Status::RESERVED->value]);
         $this->seeInDatabase('queue_jobs', ['id' => 3, 'status' => Status::RESERVED->value]);
     }
+
+    public function testSetPriorityEscapesPriorityValues(): void
+    {
+        $model   = model(QueueJobModel::class);
+        $method  = $this->getPrivateMethodInvoker($model, 'setPriority');
+        $builder = $model->builder();
+
+        $priority = [
+            'priority_key' => "default' THEN 0 ELSE 1 END --",
+            'default',
+        ];
+
+        $result = $method($builder, $priority);
+        $sql    = (string) $result->getCompiledSelect();
+
+        $this->assertStringContainsString($model->db->escape($priority['priority_key']), $sql);
+        $this->assertStringNotContainsString('priority_key', $sql);
+    }
 }

--- a/tests/Models/QueueJobModelTest.php
+++ b/tests/Models/QueueJobModelTest.php
@@ -129,7 +129,7 @@ final class QueueJobModelTest extends TestCase
         $result = $method($builder, $priority);
         $sql    = (string) $result->getCompiledSelect();
 
-        $this->assertStringContainsString($model->db->escape($priority['priority_key']), (string) $sql);
-        $this->assertStringNotContainsString('priority_key', (string) $sql);
+        $this->assertStringContainsString($model->db->escape($priority['priority_key']), $sql);
+        $this->assertStringNotContainsString('priority_key', $sql);
     }
 }


### PR DESCRIPTION
**Description**
This PR hardens database queue priority ordering by escaping priority values used in `CASE/FIELD` SQL expressions.

Closes #94 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
